### PR TITLE
chore(dockerfile): prevent using alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,16 @@
-FROM node:10-alpine
-
-RUN mkdir -p /home/node/bc/node_modules && chown -R node:node /home/node/bc
+FROM node:10
 
 WORKDIR /home/node/bc
 
-COPY --chown=node:node package*.json ./
-COPY --chown=node:node config ./config
-COPY --chown=node:node tsconfig.build.json ./
-COPY --chown=node:node tsconfig.json ./
-COPY --chown=node:node nest-cli.json ./
-COPY --chown=node:node .env ./
-COPY --chown=node:node src ./src
+COPY package*.json ./
+COPY config ./config
+COPY tsconfig.build.json ./
+COPY tsconfig.json ./
+COPY nest-cli.json ./
+COPY .env ./
+COPY src ./src
 
-USER node
-
-RUN npm install
+RUN npm ci -q
 RUN npm build
 
 EXPOSE 3000

--- a/public/Dockerfile
+++ b/public/Dockerfile
@@ -1,7 +1,5 @@
 FROM node:10 AS builder
 
-RUN mkdir -p /home/node/bc/node_modules
-
 WORKDIR /home/node/bc
 
 COPY package*.json ./

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -78,7 +78,6 @@ export class AppController {
   @Post('metadata')
   @Header('Content-Type', 'text/xml')
   async xml(@Query('xml') xml: string): Promise<string> {
-    console.log(xml);
     if (xml === AppController.XML_ENTITY_INJECTION) {
       return AppController.XML_ENTITY_INJECTION_RESPONSE;
     }


### PR DESCRIPTION
`libxmljs` crashes by segfault in `node:10-alpine` image. That's happens since alpine doesn't use `glibc`, it uses `musl`