### PR TITLE
feat(ssrf): create multiple ssrf endpoints 

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
 * **Server-Side Template Injection (SSTI)** - The endpoint /api/render receives a plain text body and renders it using the doT (http://github.com/olado/dot) templating engine.
 
 * **Server-Side Request Forgery (SSRF)** - The endpoint /api/file receives the _path_ and _type_ query parameters and returns the content of the file in _path_ with Content-Type value from the _type_ parameter. The endpoint supports relative and absolute file names, HTTP/S requests, as well as metadata URLs of Azure, Google Cloud, AWS, and DigitalOcean.
+There are specific endpoints for each cloud provider as well - `/api/file/google`, `/api/file/aws`, `/api/file/azure`, `/api/file/digital_ocean`.
 
 * **SQL injection (SQLI)** - The /api/testimonials/count endpoint receives and executes SQL query in the _query_ query parameter.
 

--- a/src/file/file.controller.ts
+++ b/src/file/file.controller.ts
@@ -198,7 +198,7 @@ export class FileController {
     @Res({ passthrough: true }) res: FastifyReply,
     @Headers('accept') acceptHeader: string,
   ) {
-    const file: Stream = await this.loadCPFile('DIGITAL_OCEAN', path);
+    const file: Stream = await this.loadCPFile(CloudProvidersMetaData.DIGITAL_OCEAN, path);
     const type = this.getContentType(contentType, acceptHeader)
     res.type(type);
 

--- a/src/file/file.controller.ts
+++ b/src/file/file.controller.ts
@@ -169,7 +169,7 @@ export class FileController {
     @Res({ passthrough: true }) res: FastifyReply,
     @Headers('accept') acceptHeader: string,
   ) {
-    const file: Stream = await this.loadCPFile('AZURE', path);
+    const file: Stream = await this.loadCPFile(CloudProvidersMetaData.AZURE, path);
     const type = this.getContentType(contentType, acceptHeader)
     res.type(type);
 

--- a/src/file/file.controller.ts
+++ b/src/file/file.controller.ts
@@ -111,7 +111,7 @@ export class FileController {
     @Res({ passthrough: true }) res: FastifyReply,
     @Headers('accept') acceptHeader: string,
   ) {
-    const file: Stream = await this.loadCPFile('GOOGLE', path);
+    const file: Stream = await this.loadCPFile(CloudProvidersMetaData.GOOGLE, path);
     const type = this.getContentType(contentType, acceptHeader)
     res.type(type);
 

--- a/src/file/file.controller.ts
+++ b/src/file/file.controller.ts
@@ -7,10 +7,8 @@ import {
   Headers,
   HttpStatus,
   Logger,
-  Param,
   Put,
   Query,
-  Req,
   Res,
 } from '@nestjs/common';
 import {

--- a/src/file/file.controller.ts
+++ b/src/file/file.controller.ts
@@ -49,7 +49,7 @@ export class FileController {
     }
   }
 
-  private async loadCPFile(cp_name: string, path: string){
+  private async loadCPFile(cpBaseUrl: string, path: string){
     if (!path.startsWith(cpBaseUrl)){
       throw new BadRequestException(`Invalid paramater 'path' ${path}`)
     }

--- a/src/file/file.controller.ts
+++ b/src/file/file.controller.ts
@@ -39,7 +39,7 @@ export class FileController {
 
   constructor(private fileService: FileService) {}
 
-  private getContentType = (contentType: string, acceptHeader: string) => {
+  private getContentType(contentType: string, acceptHeader: string) {
     if (contentType) {
       return contentType;
     } else if (acceptHeader) {

--- a/src/file/file.controller.ts
+++ b/src/file/file.controller.ts
@@ -238,11 +238,11 @@ export class FileController {
       if (typeof raw === 'string' || Buffer.isBuffer(raw)) {
         await fs.promises.access(path.dirname(file), W_OK);
         await fs.promises.writeFile(file, raw);
-        return 'File uploaded successfully';
+        return `File uploaded successfully at ${file}`;
       }
     } catch (err) {
       this.logger.error(err.message);
-      throw err;
+      throw err.message;
     }
   }
 
@@ -251,7 +251,7 @@ export class FileController {
     description: SWAGGER_DESC_READ_FILE_ON_SERVER,
   })
   @ApiNotFoundResponse({
-    description: 'File not Found',
+    description: 'File not found',
   })
   @ApiOkResponse({
     description: 'Returns requested file',

--- a/src/file/file.controller.ts
+++ b/src/file/file.controller.ts
@@ -140,7 +140,7 @@ export class FileController {
     @Res({ passthrough: true }) res: FastifyReply,
     @Headers('accept') acceptHeader: string,
   ) {
-    const file: Stream = await this.loadCPFile('AWS', path);
+    const file: Stream = await this.loadCPFile(CloudProvidersMetaData.AWS, path);
     const type = this.getContentType(contentType, acceptHeader)
     res.type(type);
 

--- a/src/file/file.controller.ts
+++ b/src/file/file.controller.ts
@@ -50,7 +50,7 @@ export class FileController {
   }
 
   private async loadCPFile(cp_name: string, path: string){
-    if (!path.startsWith(CloudProvidersMetaData[cp_name.toUpperCase()])){
+    if (!path.startsWith(cpBaseUrl)){
       throw new BadRequestException(`Invalid paramater 'path' ${path}`)
     }
     


### PR DESCRIPTION
I've added the `/api/file/google`, `/api/file/aws`, `/api/file/azure` and `/api/file/digital_ocean` endpoints which only allow ssrf payloads for the respective provider.