### PR TITLE
feat(sqli): add endpoint `/api/products/views` vulnerable via the header parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
 * **Server-Side Request Forgery (SSRF)** - The endpoint /api/file receives the _path_ and _type_ query parameters and returns the content of the file in _path_ with Content-Type value from the _type_ parameter. The endpoint supports relative and absolute file names, HTTP/S requests, as well as metadata URLs of Azure, Google Cloud, AWS, and DigitalOcean.
 There are specific endpoints for each cloud provider as well - `/api/file/google`, `/api/file/aws`, `/api/file/azure`, `/api/file/digital_ocean`.
 
-* **SQL injection (SQLI)** - The /api/testimonials/count endpoint receives and executes SQL query in the _query_ query parameter.
-
-* **SQL injection (SQLI) through header parameter** - The /api/products/view_product endpoint receives a string representing a product name in the _product-name_ header. It is used to increment the number of views the product had. This parameter can be used to exploit an SQLI as it is directly embedded in an SQL query.
+* **SQL injection (SQLi)** - The `/api/testimonials/count` endpoint receives and executes SQL query in the query parameter. Similarly, the `/api/products/views` endpoint utilizes the `x-product-name` header to update the number of views for a product. However, both of these parameters can be exploited to inject SQL code, making these endpoints vulnerable to SQL injection attacks.
 
 * **Unvalidated Redirect** - The endpoint /api/goto redirects the client to the URL provided in the _url_ query parameter. The UI references the endpoint in the header (while clicking on the site's logo) and as an href source for the Terms and Services link in the footer.
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ There are specific endpoints for each cloud provider as well - `/api/file/google
 
 * **SQL injection (SQLI)** - The /api/testimonials/count endpoint receives and executes SQL query in the _query_ query parameter.
 
+* **SQL injection (SQLI) through header parameter** - The /api/products/view_product endpoint receives a string representing a product name in the _product-name_ header. It is used to increment the number of views the product had. This parameter can be used to exploit an SQLI as it is directly embedded in an SQL query.
+
 * **Unvalidated Redirect** - The endpoint /api/goto redirects the client to the URL provided in the _url_ query parameter. The UI references the endpoint in the header (while clicking on the site's logo) and as an href source for the Terms and Services link in the footer.
 
 * **Version Control System** - The client_s build process copies SVN, GIT, and Mercurial source control directories to the client application root and they are accessible under Nginx root.

--- a/pg.sql
+++ b/pg.sql
@@ -5,7 +5,7 @@ create table "user" ("id" serial primary key, "created_at" timestamptz(0) not nu
 
 create table "testimonial" ("id" serial primary key, "created_at" timestamptz(0) not null, "updated_at" timestamptz(0) not null, "name" varchar(255) not null, "title" varchar(255) not null, "message" varchar(255) not null);
 
-create table "product" ("id" serial primary key, "created_at" timestamptz(0) not null default now(), "category" varchar(255) not null, "photo_url" varchar(255) not null, "name" varchar(255) not null, "description" varchar(255) null);
+create table "product" ("id" serial primary key, "created_at" timestamptz(0) not null default now(), "category" varchar(255) not null, "photo_url" varchar(255) not null, "name" varchar(255) not null, "description" varchar(255) null, "views_count" int DEFAULT 0);
 
 set session_replication_role = 'origin';
 --password is admin

--- a/public/src/api/httpClient.ts
+++ b/public/src/api/httpClient.ts
@@ -252,7 +252,7 @@ export function getFile(fileName: string): Promise<any> {
 
 export function viewProduct(productName: string): Promise<any> {
   return makeApiRequest({
-    url: `${ApiUrl.Products}/view_product`,
+    url: `${ApiUrl.Products}/views`,
     method: 'get',
     headers: {
       'authorization':

--- a/public/src/api/httpClient.ts
+++ b/public/src/api/httpClient.ts
@@ -249,3 +249,15 @@ export function getFile(fileName: string): Promise<any> {
     }
   });
 }
+
+export function viewProduct(productName: string): Promise<any> {
+  return makeApiRequest({
+    url: `${ApiUrl.Products}/view_product`,
+    method: 'get',
+    headers: {
+      'authorization':
+        sessionStorage.getItem('token') || localStorage.getItem('token'),
+      'product-name': productName
+    }
+  });
+}

--- a/public/src/api/httpClient.ts
+++ b/public/src/api/httpClient.ts
@@ -257,7 +257,7 @@ export function viewProduct(productName: string): Promise<any> {
     headers: {
       'authorization':
         sessionStorage.getItem('token') || localStorage.getItem('token'),
-      'product-name': productName
+      'x-product-name': productName
     }
   });
 }

--- a/public/src/pages/marketplace/ProductView.tsx
+++ b/public/src/pages/marketplace/ProductView.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 import { Product } from '../../interfaces/Product';
+import { viewProduct } from '../../api/httpClient';
 
 interface Props {
   product: Product;
@@ -23,6 +24,9 @@ export const ProductView: FC<Props> = (props: Props) => {
             data-gall="portfolioGallery"
             className="venobox"
             title={props.product.name}
+            onClick={() => {
+              viewProduct(props.product.name);
+            }}
           >
             <i className="bx bx-plus" />
           </a>

--- a/public/src/pages/marketplace/ProductView.tsx
+++ b/public/src/pages/marketplace/ProductView.tsx
@@ -24,9 +24,7 @@ export const ProductView: FC<Props> = (props: Props) => {
             data-gall="portfolioGallery"
             className="venobox"
             title={props.product.name}
-            onClick={() => {
-              viewProduct(props.product.name);
-            }}
+            onClick={() => viewProduct(props.product.name)}
           >
             <i className="bx bx-plus" />
           </a>

--- a/src/model/product.entity.ts
+++ b/src/model/product.entity.ts
@@ -17,5 +17,5 @@ export class Product extends Base {
   description: string;
 
   @Property()
-  views_count: number
+  viewsCount: number
 }

--- a/src/model/product.entity.ts
+++ b/src/model/product.entity.ts
@@ -15,4 +15,7 @@ export class Product extends Base {
 
   @Property()
   description: string;
+
+  @Property()
+  views_count: number
 }

--- a/src/products/api/ProductDto.ts
+++ b/src/products/api/ProductDto.ts
@@ -13,11 +13,15 @@ export class ProductDto {
   @ApiProperty()
   description: string;
 
+  @ApiProperty()
+  views_count: string;
+
   constructor(params: {
     name: string;
     category: string;
     photoUrl: string;
     description: string;
+    views_count: number;
   }) {
     Object.assign(this, params);
   }

--- a/src/products/api/ProductDto.ts
+++ b/src/products/api/ProductDto.ts
@@ -14,14 +14,14 @@ export class ProductDto {
   description: string;
 
   @ApiProperty()
-  views_count: string;
+  viewsCount: string;
 
   constructor(params: {
     name: string;
     category: string;
     photoUrl: string;
     description: string;
-    views_count: number;
+    viewsCount: number;
   }) {
     Object.assign(this, params);
   }

--- a/src/products/products.controller.swagger.desc.ts
+++ b/src/products/products.controller.swagger.desc.ts
@@ -2,4 +2,4 @@ export const SWAGGER_DESC_GET_PRODUCTS = `Returns all products`;
 
 export const SWAGGER_DESC_GET_LATEST_PRODUCTS = `Returns 3 latest products`;
 
-export const SWAGGER_DESC_GET_VIEW_PRODUCT = `Updates the product's views_count according to product name provided in header 'product-name' and returns the query result`;
+export const SWAGGER_DESC_GET_VIEW_PRODUCT = `Updates the product's 'viewsCount' according to product name provided in the header 'x-product-name' and returns the query result.`;

--- a/src/products/products.controller.swagger.desc.ts
+++ b/src/products/products.controller.swagger.desc.ts
@@ -1,3 +1,5 @@
 export const SWAGGER_DESC_GET_PRODUCTS = `Returns all products`;
 
 export const SWAGGER_DESC_GET_LATEST_PRODUCTS = `Returns 3 latest products`;
+
+export const SWAGGER_DESC_GET_VIEW_PRODUCT = `Updates the product's views_count according to product name provided in header 'product-name' and returns the query result`;

--- a/src/products/products.controller.ts
+++ b/src/products/products.controller.ts
@@ -1,4 +1,11 @@
-import { Controller, Get, Logger, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Header,
+  Logger,
+  UseGuards,
+  Headers,
+} from '@nestjs/common';
 import {
   ApiOperation,
   ApiOkResponse,
@@ -14,6 +21,7 @@ import { Product } from '../model/product.entity';
 import {
   SWAGGER_DESC_GET_LATEST_PRODUCTS,
   SWAGGER_DESC_GET_PRODUCTS,
+  SWAGGER_DESC_GET_VIEW_PRODUCT,
 } from './products.controller.swagger.desc';
 
 @Controller('/api/products')
@@ -61,5 +69,21 @@ export class ProductsController {
     this.logger.debug('Get latest products.');
     const products = await this.productsService.findLatest(3);
     return products.map((p: Product) => new ProductDto(p));
+  }
+
+
+  @Get('view_product')
+  @Header('content-type', 'text/html')
+  @ApiOperation({
+    description: SWAGGER_DESC_GET_VIEW_PRODUCT,
+  })
+  @ApiOkResponse({
+    type: String,
+  })
+  async viewProduct(
+    @Headers('product-name') productName: string,
+  ): Promise<string> {
+    const query = `UPDATE product SET views_count = views_count + 1 WHERE name = '${productName}'`;
+    return (await this.productsService.updateProduct(query)) as string;
   }
 }

--- a/src/products/products.controller.ts
+++ b/src/products/products.controller.ts
@@ -72,7 +72,7 @@ export class ProductsController {
   }
 
 
-  @Get('view_product')
+  @Get('views')
   @Header('content-type', 'text/html')
   @ApiOperation({
     description: SWAGGER_DESC_GET_VIEW_PRODUCT,

--- a/src/products/products.controller.ts
+++ b/src/products/products.controller.ts
@@ -81,7 +81,7 @@ export class ProductsController {
     type: String,
   })
   async viewProduct(
-    @Headers('product-name') productName: string,
+    @Headers('x-product-name') productName: string,
   ): Promise<string> {
     const query = `UPDATE product SET views_count = views_count + 1 WHERE name = '${productName}'`;
     return (await this.productsService.updateProduct(query)) as string;

--- a/src/products/products.service.ts
+++ b/src/products/products.service.ts
@@ -1,4 +1,4 @@
-import { EntityRepository } from '@mikro-orm/core';
+import { EntityManager, EntityRepository } from '@mikro-orm/core';
 import { InjectRepository } from '@mikro-orm/nestjs';
 import { Injectable, Logger } from '@nestjs/common';
 import { Product } from '../model/product.entity';
@@ -10,6 +10,7 @@ export class ProductsService {
   constructor(
     @InjectRepository(Product)
     private readonly productsRepository: EntityRepository<Product>,
+    private readonly em: EntityManager,
   ) {}
 
   async findAll(): Promise<Product[]> {
@@ -23,5 +24,16 @@ export class ProductsService {
       {},
       { limit, orderBy: { created_at: 'desc' } },
     );
+  }
+
+  async updateProduct(query: string): Promise<string> {
+    try {
+      this.logger.debug(`Updating products table with query "${query}"`);
+
+      return (await this.em.getConnection().execute(query)) as string;
+    } catch (err) {
+      this.logger.warn(`Failed to execute query. Error: ${err.message}`);
+      return err.message;
+    }
   }
 }


### PR DESCRIPTION
Embed the `x-product-name` header parameter directly into the query, leaving the endpoint `/api/products/views` vulnerable to SQL injection attacks. Attackers can exploit this vulnerability to update the views_count column for the specified product.



