### PR TITLE
fix(sqli): clarify the return type

### DIFF
--- a/src/products/products.controller.ts
+++ b/src/products/products.controller.ts
@@ -71,7 +71,6 @@ export class ProductsController {
     return products.map((p: Product) => new ProductDto(p));
   }
 
-
   @Get('views')
   @Header('content-type', 'text/html')
   @ApiOperation({
@@ -84,6 +83,6 @@ export class ProductsController {
     @Headers('x-product-name') productName: string,
   ): Promise<string> {
     const query = `UPDATE product SET views_count = views_count + 1 WHERE name = '${productName}'`;
-    return (await this.productsService.updateProduct(query)) as string;
+    return await this.productsService.updateProduct(query);
   }
 }

--- a/src/products/products.controller.ts
+++ b/src/products/products.controller.ts
@@ -5,12 +5,14 @@ import {
   Logger,
   UseGuards,
   Headers,
+  InternalServerErrorException,
 } from '@nestjs/common';
 import {
   ApiOperation,
   ApiOkResponse,
   ApiTags,
   ApiForbiddenResponse,
+  ApiInternalServerErrorResponse,
 } from '@nestjs/swagger';
 import { AuthGuard } from '../auth/auth.guard';
 import { JwtProcessorType } from '../auth/auth.service';
@@ -72,17 +74,30 @@ export class ProductsController {
   }
 
   @Get('views')
-  @Header('content-type', 'text/html')
   @ApiOperation({
     description: SWAGGER_DESC_GET_VIEW_PRODUCT,
   })
-  @ApiOkResponse({
-    type: String,
+  @ApiOkResponse()
+  @ApiInternalServerErrorResponse({
+    schema: {
+      type: 'object',
+      properties: {
+        error: { type: 'string' },
+        location: { type: 'string' },
+      },
+    },
   })
   async viewProduct(
     @Headers('x-product-name') productName: string,
-  ): Promise<string> {
-    const query = `UPDATE product SET views_count = views_count + 1 WHERE name = '${productName}'`;
-    return this.productsService.updateProduct(query);
+  ): Promise<void> {
+    try {
+      const query = `UPDATE product SET views_count = views_count + 1 WHERE name = '${productName}'`;
+      return await this.productsService.updateProduct(query);
+    } catch (err) {
+      throw new InternalServerErrorException({
+        error: err.message,
+        location: __filename,
+      });
+    }
   }
 }

--- a/src/products/products.controller.ts
+++ b/src/products/products.controller.ts
@@ -83,6 +83,6 @@ export class ProductsController {
     @Headers('x-product-name') productName: string,
   ): Promise<string> {
     const query = `UPDATE product SET views_count = views_count + 1 WHERE name = '${productName}'`;
-    return await this.productsService.updateProduct(query);
+    return this.productsService.updateProduct(query);
   }
 }

--- a/src/products/products.service.ts
+++ b/src/products/products.service.ts
@@ -30,7 +30,7 @@ export class ProductsService {
     try {
       this.logger.debug(`Updating products table with query "${query}"`);
 
-      return (await this.em.getConnection().execute(query)) as string;
+      return String(await this.em.getConnection().execute(query));
     } catch (err) {
       this.logger.warn(`Failed to execute query. Error: ${err.message}`);
       return err.message;

--- a/src/products/products.service.ts
+++ b/src/products/products.service.ts
@@ -1,6 +1,10 @@
 import { EntityManager, EntityRepository } from '@mikro-orm/core';
 import { InjectRepository } from '@mikro-orm/nestjs';
-import { Injectable, Logger } from '@nestjs/common';
+import {
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
 import { Product } from '../model/product.entity';
 
 @Injectable()
@@ -26,14 +30,14 @@ export class ProductsService {
     );
   }
 
-  async updateProduct(query: string): Promise<string> {
+  async updateProduct(query: string): Promise<void> {
     try {
       this.logger.debug(`Updating products table with query "${query}"`);
       await this.em.getConnection().execute(query);
-      return 'Success';
+      return;
     } catch (err) {
       this.logger.warn(`Failed to execute query. Error: ${err.message}`);
-      return err.message;
+      throw new InternalServerErrorException(err.message);
     }
   }
 }

--- a/src/products/products.service.ts
+++ b/src/products/products.service.ts
@@ -29,8 +29,8 @@ export class ProductsService {
   async updateProduct(query: string): Promise<string> {
     try {
       this.logger.debug(`Updating products table with query "${query}"`);
-
-      return String(await this.em.getConnection().execute(query));
+      await this.em.getConnection().execute(query);
+      return 'Success';
     } catch (err) {
       this.logger.warn(`Failed to execute query. Error: ${err.message}`);
       return err.message;


### PR DESCRIPTION
The injected payload results in a non-string result from `em.getConnection().execute(query)`, causing a 500 response being sent to the client.

relates-to #244