### PR TITLE
feat(bfla): add option to delete user profile picture with poor admin validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,5 @@ There are specific endpoints for each cloud provider as well - `/api/file/google
 * **JavaScript Vulnerabilities Scanning** - Index.html includes an older version of the jQuery library with known vulnerabilities.
 
 * **AO1 Vertical access controls** - The page /dashboard can be reached despite the rights of user.
+
+* **Broken Function Level Authorization** - The endpoint DELETE `/users/one/:id/photo?isAdmin=` can be used to delete any user's profile photo by enumerating the user IDs and setting the `isAdmin` query parameter to true, as there is no validation of it's value on the server side.

--- a/public/src/api/httpClient.ts
+++ b/public/src/api/httpClient.ts
@@ -141,8 +141,7 @@ export function postMetadata(): Promise<any> {
     url: `${ApiUrl.Metadata}`,
     method: 'post',
     headers: { 'content-type': 'text/xml' },
-    data:
-      '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE child [ <!ENTITY child SYSTEM "file:///etc/passwd"> ]><child></child>'
+    data: '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE child [ <!ENTITY child SYSTEM "file:///etc/passwd"> ]><child></child>'
   });
 }
 
@@ -163,6 +162,20 @@ export function getUserPhoto(email: string): Promise<any> {
         sessionStorage.getItem('token') || localStorage.getItem('token')
     },
     responseType: 'arraybuffer'
+  });
+}
+
+export function removeUserPhotoById(
+  id: string,
+  isAdmin: boolean
+): Promise<any> {
+  return makeApiRequest({
+    url: `${ApiUrl.Users}/one/${id}/photo?isAdmin=${isAdmin}`,
+    method: 'delete',
+    headers: {
+      authorization:
+        sessionStorage.getItem('token') || localStorage.getItem('token')
+    }
   });
 }
 

--- a/public/src/pages/main/Userprofile.tsx
+++ b/public/src/pages/main/Userprofile.tsx
@@ -1,6 +1,11 @@
 import React, { FormEvent, useEffect, useState } from 'react';
 import { Redirect } from 'react-router';
-import { getUserData, putUserData } from '../../api/httpClient';
+import {
+  getAdminStatus,
+  getUserData,
+  putUserData,
+  removeUserPhotoById
+} from '../../api/httpClient';
 import { UserData } from '../../interfaces/User';
 import { RoutePath } from '../../router/RoutePath';
 import AuthLayout from '../auth/AuthLayout';
@@ -17,6 +22,7 @@ export const Userprofile = () => {
   const email: string | null =
     sessionStorage.getItem('email') || localStorage.getItem('email');
   const [user, setUser] = useState<UserData>(defaultUserData);
+  const [isAdmin, setIsAdmin] = useState<boolean>(false);
 
   const onInput = ({ target }: { target: EventTarget | null }) => {
     const { name, value } = target as HTMLInputElement;
@@ -26,6 +32,7 @@ export const Userprofile = () => {
   useEffect(() => {
     if (email) {
       getUserData(email).then((data) => setUser(data));
+      getAdminStatus(email).then((data) => setIsAdmin(!!data.isAdmin));
     }
   }, []);
 
@@ -90,6 +97,14 @@ export const Userprofile = () => {
                 Save changes
               </button>
             </form>
+            <div>
+              <button
+                className="au-btn au-btn--block au-btn--blue m-b-20"
+                onClick={() => removeUserPhotoById(user.id, isAdmin)}
+              >
+                Remove user profile photo
+              </button>
+            </div>
           </div>
         </AuthLayout>
       ) : (

--- a/src/users/api/UserDto.ts
+++ b/src/users/api/UserDto.ts
@@ -21,6 +21,10 @@ export class UserDto {
   @ApiProperty()
   company: string;
 
+  @Expose({ groups: [BASIC_USER_INFO, FULL_USER_INFO] })
+  @ApiProperty()
+  id: number;
+
   @Expose({ groups: [FULL_USER_INFO] })
   cardNumber: string;
 
@@ -36,10 +40,6 @@ export class UserDto {
   password?: string;
 
   @Exclude()
-  @ApiHideProperty()
-  id: number;
-
-  @Exclude()
   photo: Buffer;
 
   @Expose({ groups: [FULL_USER_INFO] })
@@ -48,11 +48,9 @@ export class UserDto {
   @Expose({ groups: [FULL_USER_INFO] })
   createdAt: Date;
 
-  constructor(
-    params: {
-      [P in keyof UserDto]: UserDto[P];
-    },
-  ) {
+  constructor(params: {
+    [P in keyof UserDto]: UserDto[P];
+  }) {
     Object.assign(this, params);
   }
 }

--- a/src/users/users.controller.swagger.desc.ts
+++ b/src/users/users.controller.swagger.desc.ts
@@ -8,6 +8,8 @@ export const SWAGGER_DESC_FIND_USERS = `Returns users info contains searched sub
 
 export const SWAGGER_DESC_PHOTO_USER_BY_EMAIL = `Returns user profile photo`;
 
+export const SWAGGER_DESC_DELETE_PHOTO_USER_BY_ID = `Deletes user profile photo by user's ID`;
+
 export const SWAGGER_DESC_LDAP_SEARCH = `Performs LDAP search for user details`;
 
 export const SWAGGER_DESC_CREATE_BASIC_USER = `Creates BASIC user in PostGreSQL db`;

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -276,19 +276,7 @@ export class UsersController {
       });
     }
 
-    if (!user.photo) {
-      res.status(HttpStatus.NO_CONTENT);
-      return;
-    }
-
-    try {
-      await this.usersService.deletePhoto(id);
-    } catch (err) {
-      throw new InternalServerErrorException({
-        error: err.message,
-        location: __filename,
-      });
-    }
+    await this.usersService.deletePhoto(id);
   }
 
   @Get('/ldap')

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -32,6 +32,7 @@ import {
   ApiOkResponse,
   ApiOperation,
   ApiTags,
+  ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { CreateUserRequest } from './api/CreateUserRequest';
 import { UserDto } from './api/UserDto';
@@ -250,7 +251,10 @@ export class UsersController {
     description: 'Returns empty content if there was no user profile photo',
   })
   @ApiForbiddenResponse({
-    description: 'Returns then user is not authenticated',
+    description: 'Returns when user is not authenticated',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'Returns when isAdmin is false',
   })
   async deleteUserPhotoById(
     @Param('id') id: number,

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -228,7 +228,7 @@ export class UsersController {
         },
       });
       res.type('image/png');
-      return readable.read();
+      return readable;
     } catch (err) {
       throw new InternalServerErrorException({
         error: err.message,

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -228,7 +228,7 @@ export class UsersController {
         },
       });
       res.type('image/png');
-      return readable;
+      return readable.read();
     } catch (err) {
       throw new InternalServerErrorException({
         error: err.message,
@@ -254,14 +254,17 @@ export class UsersController {
   })
   async deleteUserPhotoById(
     @Param('id') id: number,
-    @Query('isAdmin') isAdmin: boolean,
+    @Query('isAdmin') isAdminParam: string,
     @Res({ passthrough: true }) res: FastifyReply,
   ) {
-    const user = await this.usersService.findById(id);
+    isAdminParam = isAdminParam.toLowerCase();
+    const isAdmin =
+      isAdminParam === 'true' || isAdminParam === '1' ? true : false;
     if (!isAdmin) {
       throw new UnauthorizedException();
     }
 
+    const user = await this.usersService.findById(id);
     if (!user) {
       throw new NotFoundException({
         error: 'Could not file user',

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -282,8 +282,7 @@ export class UsersController {
     }
 
     try {
-      this.usersService.deletePhoto(id);
-      return;
+      await this.usersService.deletePhoto(id);
     } catch (err) {
       throw new InternalServerErrorException({
         error: err.message,

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -55,6 +55,18 @@ export class UsersService {
     return user;
   }
 
+  async deletePhoto(id: number): Promise<User> {
+    this.log.debug(`deletePhoto for user with id ${id}`);
+    const user = await this.findById(id);
+    if (!user) {
+      throw new NotFoundError('Could not find user');
+    }
+    delete user.photo;
+
+    await this.usersRepository.persistAndFlush(user);
+    return user;
+  }
+
   async updateUserInfo(oldUser: User, newData: UserDto): Promise<UserDto> {
     this.log.debug(`updateUserInfo ${oldUser.email}`);
     const newUser = oldUser;
@@ -93,7 +105,8 @@ export class UsersService {
 
   async searchByName(query: string, limit?: number): Promise<User[]> {
     this.log.debug(`Called searchUsersByName`);
-    return this.usersRepository.find({
+    return this.usersRepository.find(
+      {
         firstName: { $like: query + '%' },
       },
       limit ? { limit } : {},


### PR DESCRIPTION
Adds endpoint DELETE `/users/one/:id/photo?isAdmin=` which allows to delete a user profile picture by the user ID. The `isAdmin` field is not validated on server side, thus it's possible to set it to true, and via ID enumeration delete any user's profile picture.