### PR TITLE
Make names shorter

### DIFF
--- a/charts/brokencrystals/Chart.yaml
+++ b/charts/brokencrystals/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   Benchmark application that uses modern technologies and implements a set of
   common security vulnerabilities
 type: application
-version: 0.0.21
+version: 0.0.22
 keywords:
   - brokencrystals
   - brkn

--- a/charts/brokencrystals/templates/_helpers.tpl
+++ b/charts/brokencrystals/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Expand the name of the chart.
 */}}
 {{- define "brokencrystals.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- default .Chart.Name .Values.nameOverride | trunc 50 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -12,13 +12,13 @@ If release name contains chart name it will be used as a full name.
 */}}
 {{- define "brokencrystals.fullname" -}}
 {{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- .Values.fullnameOverride | trunc 50 | trimSuffix "-" }}
 {{- else }}
 {{- $name := default .Chart.Name .Values.nameOverride }}
 {{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- .Release.Name | trunc 50 | trimSuffix "-" }}
 {{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- printf "%s-%s" .Release.Name $name | trunc 50 | trimSuffix "-" }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -27,7 +27,7 @@ If release name contains chart name it will be used as a full name.
 Create chart name and version as used by the chart label.
 */}}
 {{- define "brokencrystals.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 50 | trimSuffix "-" }}
 {{- end }}
 
 {{/*

--- a/charts/brokencrystals/templates/bc-postgres-deployment.yaml
+++ b/charts/brokencrystals/templates/bc-postgres-deployment.yaml
@@ -2,21 +2,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "brokencrystals.fullname" . }}-postgres-prod
+  name: {{ include "brokencrystals.fullname" . }}-postgres
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ include "brokencrystals.fullname" . }}-postgres-prod
+    app: {{ include "brokencrystals.fullname" . }}-postgres
 spec:
   selector:
     matchLabels:
-      app: {{ include "brokencrystals.fullname" . }}-postgres-prod
+      app: {{ include "brokencrystals.fullname" . }}-postgres
   template:
     metadata:
       labels:
-        app: {{ include "brokencrystals.fullname" . }}-postgres-prod
+        app: {{ include "brokencrystals.fullname" . }}-postgres
     spec:
       containers:
-        - name: {{ include "brokencrystals.fullname" . }}-postgres-prod
+        - name: {{ include "brokencrystals.fullname" . }}-postgres
           image: postgres
           livenessProbe:
             tcpSocket:
@@ -49,11 +49,11 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ include "brokencrystals.fullname" . }}-postgres-prod-service
+  name: {{ include "brokencrystals.fullname" . }}-postgres
   namespace: {{ .Release.Namespace }}
 spec:
   selector:
-    app: {{ include "brokencrystals.fullname" . }}-postgres-prod
+    app: {{ include "brokencrystals.fullname" . }}-postgres
   ports:
     - name: postgres
       port: 5432

--- a/charts/brokencrystals/templates/bc-prod-deployment.yaml
+++ b/charts/brokencrystals/templates/bc-prod-deployment.yaml
@@ -2,21 +2,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "brokencrystals.fullname" . }}-nodejs-prod
+  name: {{ include "brokencrystals.fullname" . }}-nodejs
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ include "brokencrystals.fullname" . }}-nodejs-prod
+    app: {{ include "brokencrystals.fullname" . }}-nodejs
 spec:
   selector:
     matchLabels:
-      app: {{ include "brokencrystals.fullname" . }}-nodejs-prod
+      app: {{ include "brokencrystals.fullname" . }}-nodejs
   template:
     metadata:
       labels:
-        app: {{ include "brokencrystals.fullname" . }}-nodejs-prod
+        app: {{ include "brokencrystals.fullname" . }}-nodejs
     spec:
       containers:
-        - name: {{ include "brokencrystals.fullname" . }}-nodejs-prod-app
+        - name: {{ include "brokencrystals.fullname" . }}-nodejs-app
           image: neuralegion/brokencrystals:{{ .Values.images.main }}
 #          command: ["/bin/sleep"]
 #          args: ["10000"]
@@ -25,7 +25,7 @@ spec:
               value: "https://{{ .Values.ingress.url }}"
      #         value: "https://brokencrystals.com"
             - name: DATABASE_HOST
-              value: "{{ include "brokencrystals.fullname" . }}-postgres-prod-service"
+              value: "{{ include "brokencrystals.fullname" . }}-postgres"
             - name: DATABASE_SCHEMA
               value: "bc"
             - name: DATABASE_USER
@@ -77,7 +77,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   selector:
-    app: {{ include "brokencrystals.fullname" . }}-nodejs-prod
+    app: {{ include "brokencrystals.fullname" . }}-nodejs
   ports:
     - name: http
       port: 3000

--- a/charts/brokencrystals/templates/bc-prod-proxy-deployment.yaml
+++ b/charts/brokencrystals/templates/bc-prod-proxy-deployment.yaml
@@ -2,27 +2,27 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "brokencrystals.fullname" . }}-nodejs-proxy-prod
+  name: {{ include "brokencrystals.fullname" . }}-nodejs-proxy
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ include "brokencrystals.fullname" . }}-nodejs-proxy-prod
+    app: {{ include "brokencrystals.fullname" . }}-nodejs-proxy
 spec:
   selector:
     matchLabels:
-      app: {{ include "brokencrystals.fullname" . }}-nodejs-proxy-prod
+      app: {{ include "brokencrystals.fullname" . }}-nodejs-proxy
   template:
     metadata:
       labels:
-        app: {{ include "brokencrystals.fullname" . }}-nodejs-proxy-prod
+        app: {{ include "brokencrystals.fullname" . }}-nodejs-proxy
     spec:
       containers:
-        - name: {{ include "brokencrystals.fullname" . }}-nodejs-proxy-prod-app
+        - name: {{ include "brokencrystals.fullname" . }}-nodejs-proxy-app
           image: neuralegion/brokencrystals-proxy-http:{{ .Values.images.client }}
           env:
             - name: URL
               value: "https://{{ .Values.ingress.url }}"
             - name: DATABASE_HOST
-              value: "{{ include "brokencrystals.fullname" . }}-postgres-prod-service"
+              value: "{{ include "brokencrystals.fullname" . }}-postgres"
             - name: DATABASE_SCHEMA
               value: "bc"
             - name: DATABASE_USER
@@ -78,11 +78,11 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ include "brokencrystals.fullname" . }}-nodejs-proxy-prod-service
+  name: {{ include "brokencrystals.fullname" . }}-nodejs-proxy
   namespace: {{ .Release.Namespace }}
 spec:
   selector:
-    app: {{ include "brokencrystals.fullname" . }}-nodejs-proxy-prod
+    app: {{ include "brokencrystals.fullname" . }}-nodejs-proxy
   ports:
     - name: http
       port: 80

--- a/charts/brokencrystals/templates/ingress.yaml
+++ b/charts/brokencrystals/templates/ingress.yaml
@@ -24,7 +24,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ include "brokencrystals.fullname" . }}-nodejs-proxy-prod-service
+                name: {{ include "brokencrystals.fullname" . }}-nodejs-proxy
                 port:
                   number: 80
 
@@ -32,7 +32,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "brokencrystals.fullname" . }}-prod-keycloak
+  name: {{ include "brokencrystals.fullname" . }}-keycloak
   namespace: {{ .Release.Namespace }}
   annotations:
     kubernetes.io/ingress.class: nginx
@@ -54,6 +54,6 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ include "brokencrystals.fullname" . }}-keycloak-prod-service
+                name: {{ include "brokencrystals.fullname" . }}-keycloak
                 port:
                   number: 8080

--- a/charts/brokencrystals/templates/keycloak-deployment.yaml
+++ b/charts/brokencrystals/templates/keycloak-deployment.yaml
@@ -2,21 +2,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "brokencrystals.fullname" . }}-keycloak-prod
+  name: {{ include "brokencrystals.fullname" . }}-keycloak
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ include "brokencrystals.fullname" . }}-keycloak-prod
+    app: {{ include "brokencrystals.fullname" . }}-keycloak
 spec:
   selector:
     matchLabels:
-      app: {{ include "brokencrystals.fullname" . }}-keycloak-prod
+      app: {{ include "brokencrystals.fullname" . }}-keycloak
   template:
     metadata:
       labels:
-        app: {{ include "brokencrystals.fullname" . }}-keycloak-prod
+        app: {{ include "brokencrystals.fullname" . }}-keycloak
     spec:
       containers:
-        - name: {{ include "brokencrystals.fullname" . }}-keycloak-prod
+        - name: {{ include "brokencrystals.fullname" . }}-keycloak
           image: jboss/keycloak:latest
           resources:
             requests:
@@ -34,7 +34,7 @@ spec:
             - name: DB_VENDOR
               value: "POSTGRES"
             - name: DB_ADDR
-              value: "{{ include "brokencrystals.fullname" . }}-keycloak-postgres-prod-service"
+              value: "{{ include "brokencrystals.fullname" . }}-keycloak-db"
             - name: DB_DATABASE
               value: "keycloak"
             - name: DB_SCHEMA
@@ -66,11 +66,11 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ include "brokencrystals.fullname" . }}-keycloak-prod-service
+  name: {{ include "brokencrystals.fullname" . }}-keycloak
   namespace: {{ .Release.Namespace }}
 spec:
   selector:
-    app: {{ include "brokencrystals.fullname" . }}-keycloak-prod
+    app: {{ include "brokencrystals.fullname" . }}-keycloak
   ports:
     - name: http
       port: 8080

--- a/charts/brokencrystals/templates/keycloak-postgres-deployment.yaml
+++ b/charts/brokencrystals/templates/keycloak-postgres-deployment.yaml
@@ -2,21 +2,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "brokencrystals.fullname" . }}-keycloak-postgres-prod
+  name: {{ include "brokencrystals.fullname" . }}-keycloak-db
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ include "brokencrystals.fullname" . }}-keycloak-postgres-prod
+    app: {{ include "brokencrystals.fullname" . }}-keycloak-db
 spec:
   selector:
     matchLabels:
-      app: {{ include "brokencrystals.fullname" . }}-keycloak-postgres-prod
+      app: {{ include "brokencrystals.fullname" . }}-keycloak-db
   template:
     metadata:
       labels:
-        app: {{ include "brokencrystals.fullname" . }}-keycloak-postgres-prod
+        app: {{ include "brokencrystals.fullname" . }}-keycloak-db
     spec:
       containers:
-        - name: {{ include "brokencrystals.fullname" . }}-keycloak-postgres-prod
+        - name: {{ include "brokencrystals.fullname" . }}-keycloak-db
           image: postgres:12.2-alpine
           livenessProbe:
             tcpSocket:
@@ -40,11 +40,11 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ include "brokencrystals.fullname" . }}-keycloak-postgres-prod-service
+  name: {{ include "brokencrystals.fullname" . }}-keycloak-db
   namespace: {{ .Release.Namespace }}
 spec:
   selector:
-    app: {{ include "brokencrystals.fullname" . }}-keycloak-postgres-prod
+    app: {{ include "brokencrystals.fullname" . }}-keycloak-db
   ports:
     - name: postgres-keycloak
       port: 5432


### PR DESCRIPTION
**Helm Charts.**
Sometimes when running tests you may encounter problems like this:
`Service “hmm597-7803-e2e-brokencrystals-dev-keycloak-postgres-prod-service” is invalid: metadata.name: Invalid value: “hmm597-7803-e2e-brokencrystals-dev-keycloak-postgres-prod-service”: must be no more than 63 characters`
So I shortened the name suffixes and reduced the _trunc_ function parameter to 50, which applies to part of the name.