### PR TITLE
fix: ensure SQL processor uses key returned by query

### DIFF
--- a/src/auth/jwt/jwt.token.with.sql.kid.processor.ts
+++ b/src/auth/jwt/jwt.token.with.sql.kid.processor.ts
@@ -28,10 +28,10 @@ export class JwtTokenWithSqlKIDProcessor extends JwtTokenProcessor {
     this.log.debug(`Executing key fetching query: ${query}`);
     const keyRow: { key: string } = await this.em
       .getConnection()
-      .execute(query);
+      .execute(query, [], 'get');
     this.log.debug(`Key is ${keyRow.key}`);
 
-    return decode(token, this.key, false, 'HS256');
+    return decode(token, keyRow.key, false, 'HS256');
   }
 
   async createToken(payload: unknown): Promise<string> {


### PR DESCRIPTION
This PR addresses two issues in the SQL KID processor which prevent it being exploitable in the intended fashion.

1. The code following the SQL query assumes a single result returned by the query, while the `execute` method uses the default "all" method which returns a list of results. This has been modified to use the "get" method which will return a single result.
2. After the query has been executed, the key used is still always the default key, rather than the one returned by a query. This means that the JWT will only be validated if signed using the default key rather than an attacker-specified key. This has been modified to always use the key returned by the query, allowing the attacker to control the key used to sign the token.