### PR TITLE
fix: use correct env variable name for enabling ORM debug mode

### DIFF
--- a/src/orm/orm.config.factory.ts
+++ b/src/orm/orm.config.factory.ts
@@ -37,7 +37,7 @@ export class OrmConfigFactory {
       highlighter: new SqlHighlighter(),
       debug:
         this.configService.get<string>(
-          OrmModuleConfigProperties.ENV_DATABASE_PORT
+          OrmModuleConfigProperties.ENV_DATABASE_DEBUG
         ) === 'true',
       logger: logger.log.bind(logger)
     });


### PR DESCRIPTION
The incorrect environment variable was used to control whether the ORM generated debug logs. This has been corrected.