### PR TITLE
fix(ci): redundant triggers to push unstable

### DIFF
--- a/.github/workflows/build_and_push_unstable.yml
+++ b/.github/workflows/build_and_push_unstable.yml
@@ -6,9 +6,6 @@ on:
         description: 'Tag prefix to use (defaults to unstable)'
         required: false
         default: 'unstable'
-  push:
-    branches:
-      - stable
 
 jobs:
   docker-build-push:


### PR DESCRIPTION
unstable tag is already pushed on 
https://github.com/NeuraLegion/brokencrystals/blob/stable/.github/workflows/build_and_push_stable.yml#L29