### PR TITLE
fix(endpoints): update google, digital cloud endpoints metadata samples

### DIFF
--- a/src/file/cloud.providers.metadata.ts
+++ b/src/file/cloud.providers.metadata.ts
@@ -15,22 +15,12 @@ export class CloudProvidersMetaData {
   private providers: Map<string, string> = new Map<string, string>();
 
   constructor() {
-    //TODO - set correct values
-    this.providers.set(
+     this.providers.set(
       CloudProvidersMetaData.GOOGLE,
       `
-        attributes/
-        cpu-platform
-        description
-        instance
-        hostname
-        project
-        disks
-        service-accounts
-        tags
-        guest-attributes
-        maintenance-event
-        network-interfaces/
+        instance/
+        oslogin/
+        project/
     `.trim()
     );
     this.providers.set(

--- a/src/file/cloud.providers.metadata.ts
+++ b/src/file/cloud.providers.metadata.ts
@@ -8,14 +8,16 @@ export class CloudProvidersMetaData {
   public static readonly AZURE: string =
     'http://169.254.169.254/metadata/instance';
   public static readonly DIGITAL_OCEAN: string =
-    'http://169.254.169.254/metadata/v1/';
+    'http://169.254.169.254/metadata/v1';
+  public static readonly DIGITAL_OCEAN_JSON: string =
+    'http://169.254.169.254/metadata/v1.json'; //https://docs.digitalocean.com/reference/api/metadata/#tag/Droplet-Properties
   public static readonly AWS: string =
     'http://169.254.169.254/latest/meta-data/';
 
   private providers: Map<string, string> = new Map<string, string>();
 
   constructor() {
-     this.providers.set(
+    this.providers.set(
       CloudProvidersMetaData.GOOGLE,
       `
         instance/
@@ -242,6 +244,7 @@ export class CloudProvidersMetaData {
         interfaces/
         dns/
         floating_ip/
+        reserved_ip/
         tags/
         features/
     `.trim()


### PR DESCRIPTION
1) google endpoint api was updated and now  returns different structure (https://github.com/NeuraLegion/nexploit/pull/4659)

2) digital ocean endpoint had two overlapping samples, one of which was in .json format. Request string updated according to the current official API documentation (https://docs.digitalocean.com/reference/api/metadata/#tag/Droplet-Properties/operation/getMetadataIndex)

SET-1771