### PR TITLE
fix(fpd): reduce amount of endpoints that disclosured a full path in errors

### DIFF
--- a/src/components/global-exception.filter.ts
+++ b/src/components/global-exception.filter.ts
@@ -21,7 +21,7 @@ export class GlobalExceptionFilter extends BaseExceptionFilter {
     }
 
     const unprocessableException = new InternalServerErrorException(
-      { error: (exception as Error).message, location: __filename },
+      { error: (exception as Error).message },
       'An internal error has occurred, and the API was unable to service your request.'
     );
 


### PR DESCRIPTION
SET-1777

FPD is still available by:

```
➜  ~ curl  "http://localhost:3000/api/file?path=nonexisting"
{"error":"ENOENT: no such file or directory, access '/usr/src/app/nonexisting'","location":"global-exception.filter.js"}%  
```