### PR TITLE
fix(frontend): infinit loader when redirected from /adminpage to home

### DIFF
--- a/client/src/pages/main/Main.tsx
+++ b/client/src/pages/main/Main.tsx
@@ -9,8 +9,21 @@ import Footer from './Footer';
 
 // Add jQuery to Window interface
 declare global {
+  // Define jQuery interface to avoid using 'any'
+  interface JQuery {
+    delay(ms: number): JQuery;
+    fadeOut(speed: string, callback?: (this: HTMLElement) => void): JQuery;
+    remove(): void;
+    length: number;
+  }
+
+  // Define jQuery static interface
+  interface JQueryStatic {
+    (selector: string | HTMLElement): JQuery;
+  }
+
   interface Window {
-    jQuery: any;
+    jQuery: JQueryStatic;
   }
 }
 

--- a/client/src/pages/main/Main.tsx
+++ b/client/src/pages/main/Main.tsx
@@ -1,10 +1,18 @@
 import type { FC } from 'react';
+import { useEffect } from 'react';
 import Counts from './Counts';
 import Hero from './Hero';
 import Header from './Header/Header';
 import FAQ from './FAQ';
 import Contact from './Contact';
 import Footer from './Footer';
+
+// Add jQuery to Window interface
+declare global {
+  interface Window {
+    jQuery: any;
+  }
+}
 
 const extractIframeUrlParam = (): string | null => {
   const { searchParams } = new URL(window.location.href);
@@ -14,6 +22,22 @@ const extractIframeUrlParam = (): string | null => {
 
 export const Main: FC = () => {
   const mapTitle = extractIframeUrlParam();
+
+  // Ensure preloader is handled properly when component mounts
+  useEffect(() => {
+    // Small delay to ensure the DOM is fully rendered
+    setTimeout(() => {
+      const $ = window.jQuery;
+      if ($ && $('#preloader').length) {
+        $('#preloader')
+          .delay(100)
+          .fadeOut('slow', function (this: HTMLElement) {
+            $(this).remove();
+          });
+      }
+    }, 50);
+  }, []);
+
   return (
     <>
       <Header />


### PR DESCRIPTION
This fix resolves an issue where the browser would hang in a loading state when redirected from /adminpage to the home page in an unauthenticated state.
 The solution adds proper preloader handling in the Main component with a useEffect hook and includes type declarations for jQuery in the Window interface.

SET-1786