### PR TITLE
fix(benchmark): use symmetric encryption for hmac JWT tokens

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -113,7 +113,7 @@ export class AuthService {
 
     this.processors.set(
       JwtProcessorType.HMAC,
-      new JwtTokenWithHMACKeysProcessor(publicKey, privateKey)
+      new JwtTokenWithHMACKeysProcessor(privateKey)
     );
     this.processors.set(
       JwtProcessorType.RSA_SIGNATURE,

--- a/src/auth/jwt/jwt.token.with.hmac.keys.processor.ts
+++ b/src/auth/jwt/jwt.token.with.hmac.keys.processor.ts
@@ -4,8 +4,7 @@ import { encode, decode } from 'jwt-simple';
 
 export class JwtTokenWithHMACKeysProcessor extends JwtTokenProcessor {
   constructor(
-    private publicKey: string,
-    private privateKey: string
+     private privateKey: string
   ) {
     super(new Logger(JwtTokenWithHMACKeysProcessor.name));
   }
@@ -13,7 +12,11 @@ export class JwtTokenWithHMACKeysProcessor extends JwtTokenProcessor {
   async validateToken(token: string): Promise<unknown> {
     this.log.debug('Call validateToken');
 
-    return decode(token, this.publicKey, false, 'HS256');
+    const [header, payload] = this.parse(token);
+    if (header.alg === 'none') {
+      return payload;
+    }
+    return decode(token, this.privateKey, false, 'HS256');
   }
 
   async createToken(payload: unknown): Promise<string> {

--- a/src/auth/jwt/jwt.token.with.hmac.keys.processor.ts
+++ b/src/auth/jwt/jwt.token.with.hmac.keys.processor.ts
@@ -3,9 +3,7 @@ import { JwtTokenProcessor as JwtTokenProcessor } from './jwt.token.processor';
 import { encode, decode } from 'jwt-simple';
 
 export class JwtTokenWithHMACKeysProcessor extends JwtTokenProcessor {
-  constructor(
-     private privateKey: string
-  ) {
+  constructor(private privateKey: string) {
     super(new Logger(JwtTokenWithHMACKeysProcessor.name));
   }
 


### PR DESCRIPTION
- Implementation unified with [`src/auth/jwt/jwt.token.with.rsa.keys.processor.ts`](https://github.com/NeuraLegion/brokencrystals/blob/0a8dd4fcef6703999262489dcde2905c87119e9e/src/auth/jwt/jwt.token.with.rsa.keys.processor.ts#L4)
- HMAC is symmetric algorithm, so private/public keys were not necessary. I left only private key usage in code.

[SET-1780](https://brightsec.atlassian.net/browse/SET-1780)

[SET-1780]: https://brightsec.atlassian.net/browse/SET-1780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ