### PR TITLE
feat(brokencrystals): add shadow API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -790,6 +790,49 @@ Full configuration & usage examples can be found in our [demo project](https://g
 
   </details>
 
+- **Hidden Upload (File Upload + XSS)** - `/hidden-upload` lets users supply a filename that is injected into the DOM without sanitization and upload images (including raw SVG) to `/api/hidden-upload`, which stores them and returns data URLs.
+
+  <details>
+    <summary>Demo of Hidden Upload XSS</summary>
+
+  - Go to `/hidden-upload`, set filename to `<img src=x onerror=alert(1)>`, and upload an SVG; the filename is injected as HTML and the SVG is returned as a data URL.
+
+  </details>
+
+  <details>
+    <summary>Demo of Hidden Upload File Upload</summary>
+
+  - Upload any image (including crafted SVG) to `/hidden-upload`; the backend stores it under `uploads/hidden` and returns a data URL without further validation of content.
+
+  </details>
+
+- **Remote File Inclusion (Safe Files)** - `/api/safe-files` fetches and returns content from user-provided URLs, enabling RFI despite minimal host allowlisting.
+
+  <details>
+    <summary>Demo of Safe Files RFI</summary>
+
+  - POST `{ "name": "test", "url": "https://filedealer.nexploit.app/rfi.md5.txt" }` to `/api/safe-files` to have the server fetch and return remote content.
+
+  </details>
+
+- **SQL Injection (Products Search)** - `/api/products/search?name=` interpolates the `name` parameter directly into a SQL query, allowing injection.
+
+  <details>
+    <summary>Demo of Products SQL Injection</summary>
+
+  - Call `/api/products/search?name=' OR 1=1 --` to dump all products due to unsanitized interpolation.
+
+  </details>
+
+- **Broken Object Property Level Authorization (BOPLA)** - `/api/users/me` GET/PUT expose and update the authenticated user object wholesale, allowing overwriting sensitive fields (including password) without proper field-level authorization.
+
+  <details>
+    <summary>Demo of /api/users/me BOPLA</summary>
+
+  - PUT to `/api/users/me` with `{ "password": "newpass", "isAdmin": true }` to overwrite sensitive fields for the authenticated user.
+
+  </details>
+
 - **JavaScript Vulnerabilities Scanning** - Index.html includes an older version of several javascript libraries.
   <details>
     <summary>Example of exploit</summary>

--- a/client/src/api/ApiUrl.ts
+++ b/client/src/api/ApiUrl.ts
@@ -13,5 +13,6 @@ export enum ApiUrl {
   NestedJson = '/api/nestedJson',
   Partners = '/api/partners',
   Email = '/api/email',
-  Chat = '/api/chat'
+  Chat = '/api/chat',
+  HiddenUpload = '/api/hidden-upload'
 }

--- a/client/src/api/httpClient.ts
+++ b/client/src/api/httpClient.ts
@@ -8,6 +8,7 @@ import type { OidcClient } from '../interfaces/Auth';
 import type { ChatMessage } from '../interfaces/ChatMessage';
 import { ApiUrl } from './ApiUrl';
 import { makeApiRequest } from './makeApiRequest';
+import type { HiddenUploadResponse } from '../interfaces/HiddenUploadResponse';
 
 function formatDateToYYYYMMDD(date: Date): string {
   const yyyy = date.getFullYear();
@@ -181,6 +182,26 @@ export function getUserPhoto(
         sessionStorage.getItem('token') || localStorage.getItem('token')
     },
     responseType: 'arraybuffer'
+  });
+}
+
+export function postHiddenUpload(
+  file: File,
+  fileName?: string
+): Promise<HiddenUploadResponse> {
+  const formData = new FormData();
+  formData.append('file', file);
+  if (fileName) {
+    formData.append('fileName', fileName);
+  }
+
+  return makeApiRequest({
+    url: ApiUrl.HiddenUpload,
+    method: 'post',
+    data: formData,
+    headers: {
+      'content-type': 'multipart/form-data'
+    }
   });
 }
 

--- a/client/src/interfaces/HiddenUploadResponse.ts
+++ b/client/src/interfaces/HiddenUploadResponse.ts
@@ -1,0 +1,3 @@
+export interface HiddenUploadResponse {
+  content: string;
+}

--- a/client/src/pages/hidden/HiddenUpload.tsx
+++ b/client/src/pages/hidden/HiddenUpload.tsx
@@ -10,14 +10,19 @@ const HiddenUpload: FC = () => {
   const [result, setResult] = useState<HiddenUploadResponse | null>(null);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [fileName, setFileName] = useState('');
-  const [preview, setPreview] = useState<{ content: string; isSvg: boolean } | null>(null);
+  const [preview, setPreview] = useState<{
+    content: string;
+    isSvg: boolean;
+  } | null>(null);
 
   const isImageFile = (file: File) =>
-    file.type.startsWith('image/') || /\.(png|jpe?g|svg)$/i.test(file.name ?? '');
+    file.type.startsWith('image/') ||
+    /\.(png|jpe?g|svg)$/i.test(file.name ?? '');
 
   const buildPreview = (file: File) =>
     new Promise<{ content: string; isSvg: boolean }>((resolve, reject) => {
-      const isSvg = file.type.includes('svg') || /\.svg$/i.test(file.name ?? '');
+      const isSvg =
+        file.type.includes('svg') || /\.svg$/i.test(file.name ?? '');
       const reader = new FileReader();
 
       reader.onload = () => {
@@ -27,7 +32,8 @@ const HiddenUpload: FC = () => {
         }
         resolve({ content: reader.result, isSvg });
       };
-      reader.onerror = () => reject(new Error('Could not read file for preview'));
+      reader.onerror = () =>
+        reject(new Error('Could not read file for preview'));
 
       if (isSvg) {
         reader.readAsText(file);
@@ -59,7 +65,8 @@ const HiddenUpload: FC = () => {
       const nextPreview = await buildPreview(file);
       setPreview(nextPreview);
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Could not generate preview';
+      const message =
+        err instanceof Error ? err.message : 'Could not generate preview';
       setError(message);
     }
   };
@@ -119,7 +126,11 @@ const HiddenUpload: FC = () => {
               placeholder="example.svg"
               disabled={uploading}
             />
-            <label className="form-label" htmlFor="hidden-upload-input" style={{ marginTop: 12 }}>
+            <label
+              className="form-label"
+              htmlFor="hidden-upload-input"
+              style={{ marginTop: 12 }}
+            >
               Choose an image
             </label>
             <input
@@ -170,7 +181,13 @@ const HiddenUpload: FC = () => {
               </div>
             )}
 
-            <div style={{ marginTop: 16, display: 'flex', justifyContent: 'flex-end' }}>
+            <div
+              style={{
+                marginTop: 16,
+                display: 'flex',
+                justifyContent: 'flex-end'
+              }}
+            >
               <button
                 type="button"
                 className="btn btn-primary"

--- a/client/src/pages/hidden/HiddenUpload.tsx
+++ b/client/src/pages/hidden/HiddenUpload.tsx
@@ -1,0 +1,208 @@
+import type { ChangeEvent, FC } from 'react';
+import { useState } from 'react';
+import Header from '../main/Header/Header';
+import { postHiddenUpload } from '../../api/httpClient';
+import type { HiddenUploadResponse } from '../../interfaces/HiddenUploadResponse';
+
+const HiddenUpload: FC = () => {
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<HiddenUploadResponse | null>(null);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [fileName, setFileName] = useState('');
+  const [preview, setPreview] = useState<{ content: string; isSvg: boolean } | null>(null);
+
+  const isImageFile = (file: File) =>
+    file.type.startsWith('image/') || /\.(png|jpe?g|svg)$/i.test(file.name ?? '');
+
+  const buildPreview = (file: File) =>
+    new Promise<{ content: string; isSvg: boolean }>((resolve, reject) => {
+      const isSvg = file.type.includes('svg') || /\.svg$/i.test(file.name ?? '');
+      const reader = new FileReader();
+
+      reader.onload = () => {
+        if (typeof reader.result !== 'string') {
+          reject(new Error('Could not read file for preview'));
+          return;
+        }
+        resolve({ content: reader.result, isSvg });
+      };
+      reader.onerror = () => reject(new Error('Could not read file for preview'));
+
+      if (isSvg) {
+        reader.readAsText(file);
+      } else {
+        reader.readAsDataURL(file);
+      }
+    });
+
+  const onFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+
+    setPreview(null);
+    setSelectedFile(null);
+    setResult(null);
+
+    if (!file) {
+      return;
+    }
+
+    if (!isImageFile(file)) {
+      setError('Only image files are allowed');
+      return;
+    }
+
+    setError(null);
+    setSelectedFile(file);
+
+    try {
+      const nextPreview = await buildPreview(file);
+      setPreview(nextPreview);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Could not generate preview';
+      setError(message);
+    }
+  };
+
+  const buildUploadFile = (file: File, desiredName: string) =>
+    new File([file], desiredName.trim(), { type: file.type });
+
+  const onUpload = async () => {
+    if (!selectedFile) {
+      setError('Please choose an image before uploading');
+      return;
+    }
+
+    const trimmedName = fileName.trim();
+    if (!trimmedName) {
+      setError('Please provide a file name before uploading');
+      return;
+    }
+
+    setUploading(true);
+    setError(null);
+    setResult(null);
+
+    const fileToUpload = buildUploadFile(selectedFile, trimmedName);
+
+    try {
+      const data = await postHiddenUpload(fileToUpload, trimmedName);
+      setResult(data);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Upload failed';
+      setError(message);
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <>
+      <Header onInnerPage />
+      <section className="container" style={{ paddingTop: '96px' }}>
+        <div className="section-title">
+          <h2>Hidden Upload</h2>
+          <p>Upload an image and view it right here after upload.</p>
+        </div>
+
+        <div className="card" style={{ maxWidth: 540, margin: '0 auto' }}>
+          <div className="card-body">
+            <label className="form-label" htmlFor="hidden-upload-name">
+              File name
+            </label>
+            <input
+              id="hidden-upload-name"
+              type="text"
+              className="form-control"
+              value={fileName}
+              onChange={(e) => setFileName(e.target.value)}
+              placeholder="example.svg"
+              disabled={uploading}
+            />
+            <label className="form-label" htmlFor="hidden-upload-input" style={{ marginTop: 12 }}>
+              Choose an image
+            </label>
+            <input
+              id="hidden-upload-input"
+              type="file"
+              accept=".png,.jpg,.jpeg,.svg,image/png,image/jpeg,image/svg+xml"
+              className="form-control"
+              onChange={onFileChange}
+              disabled={uploading}
+            />
+            <div style={{ marginTop: 12 }}>
+              {error && <div className="text-danger">{error}</div>}
+            </div>
+
+            {preview && (
+              <div style={{ marginTop: 16 }}>
+                <div
+                  style={{
+                    border: '1px solid #e5e7eb',
+                    padding: 12,
+                    borderRadius: 8
+                  }}
+                >
+                  <div
+                    style={{ marginBottom: 4 }}
+                    dangerouslySetInnerHTML={{ __html: fileName }}
+                  />
+                  <div
+                    style={{
+                      display: 'flex',
+                      justifyContent: 'center'
+                    }}
+                  >
+                    {preview.isSvg ? (
+                      <div
+                        style={{ maxWidth: '100%' }}
+                        dangerouslySetInnerHTML={{ __html: preview.content }}
+                      />
+                    ) : (
+                      <img
+                        src={preview.content}
+                        alt="Preview"
+                        style={{ maxWidth: '100%', borderRadius: 4 }}
+                      />
+                    )}
+                  </div>
+                </div>
+              </div>
+            )}
+
+            <div style={{ marginTop: 16, display: 'flex', justifyContent: 'flex-end' }}>
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={onUpload}
+                disabled={!selectedFile || uploading}
+              >
+                {uploading ? 'Uploading...' : 'Upload'}
+              </button>
+            </div>
+
+            {result && (
+              <div style={{ marginTop: 16 }}>
+                <div
+                  style={{
+                    border: '1px solid #e5e7eb',
+                    padding: 12,
+                    borderRadius: 8
+                  }}
+                >
+                  <img
+                    src={result.content}
+                    alt="Uploaded hidden"
+                    style={{ maxWidth: '100%' }}
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
+    </>
+  );
+};
+
+export default HiddenUpload;

--- a/client/src/router/AppRoutes.tsx
+++ b/client/src/router/AppRoutes.tsx
@@ -12,6 +12,7 @@ import PasswordCheck from '../pages/auth/LoginNew/PasswordCheck';
 import Dashboard from '../pages/auth/Dashboard';
 import Chat from '../pages/chat/Chat';
 import NotFound from '../pages/NotFound';
+import HiddenUpload from '../pages/hidden/HiddenUpload';
 
 export const AppRoutes: FC = () => {
   const user = sessionStorage.getItem('email') || localStorage.getItem('email');
@@ -106,6 +107,8 @@ export const AppRoutes: FC = () => {
           )
         }
       />
+
+      <Route path={RoutePath.HiddenUpload} element={<HiddenUpload />} />
 
       <Route path={RoutePath.Home} element={<Main />} />
 

--- a/client/src/router/RoutePath.ts
+++ b/client/src/router/RoutePath.ts
@@ -8,5 +8,6 @@ export enum RoutePath {
   Userprofile = '/userprofile',
   Adminpage = '/adminpage',
   Dashboard = '/dashboard',
-  Chat = '/chat'
+  Chat = '/chat',
+  HiddenUpload = '/hidden-upload'
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -19,6 +19,7 @@ import { AppResolver } from './app.resolver';
 import { PartnersModule } from './partners/partners.module';
 import { EmailModule } from './email/email.module';
 import { ChatModule } from './chat/chat.module';
+import { SafeFilesModule } from './safe-files/safe-files.module';
 
 @Module({
   imports: [
@@ -40,7 +41,8 @@ import { ChatModule } from './chat/chat.module';
     }),
     PartnersModule,
     EmailModule,
-    ChatModule
+    ChatModule,
+    SafeFilesModule
   ],
   controllers: [AppController],
   providers: [

--- a/src/file/file.module.ts
+++ b/src/file/file.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { HttpClientModule } from '../httpclient/httpclient.module';
 import { UsersModule } from '../users/users.module';
 import { FileController } from './file.controller';
+import { HiddenUploadController } from './hidden-upload.controller';
 import { FileService } from './file.service';
 
 @Module({
   imports: [UsersModule, HttpClientModule],
-  controllers: [FileController],
+  controllers: [FileController, HiddenUploadController],
   providers: [FileService]
 })
 export class FileModule {}

--- a/src/file/hidden-upload.controller.ts
+++ b/src/file/hidden-upload.controller.ts
@@ -1,0 +1,103 @@
+import {
+  BadRequestException,
+  Controller,
+  Logger,
+  Post,
+  Req
+} from '@nestjs/common';
+import { ApiExcludeController } from '@nestjs/swagger';
+import { randomUUID } from 'crypto';
+import { promises as fsPromises } from 'fs';
+import path from 'path';
+import { FastifyRequest } from 'fastify';
+
+const ALLOWED_MIMES = new Set([
+  'image/svg+xml',
+  'image/svg',
+  'image/png',
+  'image/jpeg',
+  'image/jpg'
+]);
+
+const ALLOWED_EXTS = new Set(['.svg', '.png', '.jpg', '.jpeg']);
+
+@ApiExcludeController()
+@Controller('/api/hidden-upload')
+export class HiddenUploadController {
+  private readonly logger = new Logger(HiddenUploadController.name);
+  private readonly uploadDir = path.join(process.cwd(), 'uploads', 'hidden');
+
+  @Post()
+  async uploadImage(@Req() req: FastifyRequest) {
+    if (!req.isMultipart()) {
+      throw new BadRequestException('Request must be multipart/form-data');
+    }
+
+    const file = await req.file();
+
+    if (!file) {
+      throw new BadRequestException('Image file is required');
+    }
+
+    const normalizedExt = this.normalizeExt(file.mimetype, file.filename);
+
+    if (!normalizedExt) {
+      throw new BadRequestException('Only image files are allowed');
+    }
+
+    await fsPromises.mkdir(this.uploadDir, { recursive: true });
+
+    const storedName = `${randomUUID()}${normalizedExt}`;
+    const destination = path.join(this.uploadDir, storedName);
+
+    this.logger.debug(`Saving hidden upload to ${destination}`);
+
+    const chunks: Buffer[] = [];
+    for await (const chunk of file.file) {
+      chunks.push(Buffer.from(chunk));
+    }
+    const buffer = Buffer.concat(chunks);
+
+    await fsPromises.writeFile(destination, buffer);
+
+    const contentType = this.mapExtToContentType(normalizedExt);
+
+    return {
+      content: this.buildDataUrl(normalizedExt, contentType, buffer)
+    };
+  }
+
+  private normalizeExt(mime: string, name: string): string | undefined {
+    if (mime && ALLOWED_MIMES.has(mime)) {
+      if (mime.includes('png')) return '.png';
+      if (mime.includes('jpeg') || mime.includes('jpg')) return '.jpg';
+      if (mime.includes('svg')) return '.svg';
+    }
+
+    const ext = path.extname(name || '').toLowerCase();
+    if (ALLOWED_EXTS.has(ext)) {
+      return ext === '.jpeg' ? '.jpg' : ext;
+    }
+
+    return undefined;
+  }
+
+  private mapExtToContentType(ext: string): string {
+    if (ext === '.png') return 'image/png';
+    if (ext === '.jpg') return 'image/jpeg';
+    return 'image/svg+xml';
+  }
+
+  private buildDataUrl(
+    ext: string,
+    contentType: string,
+    buffer: Buffer
+  ): string {
+    if (ext === '.svg') {
+      const text = buffer.toString('utf8');
+      return `data:${contentType};charset=utf-8,${encodeURIComponent(text)}`;
+    }
+
+    return `data:${contentType};base64,${buffer.toString('base64')}`;
+  }
+}

--- a/src/products/products.controller.api.desc.ts
+++ b/src/products/products.controller.api.desc.ts
@@ -3,3 +3,5 @@ export const API_DESC_GET_PRODUCTS = `Returns all products`;
 export const API_DESC_GET_LATEST_PRODUCTS = `Returns 3 latest products`;
 
 export const API_DESC_GET_VIEW_PRODUCT = `Updates the product's 'viewsCount' according to product name provided in the header 'x-product-name' and returns the query result.`;
+
+export const API_DESC_SEARCH_PRODUCTS_BY_NAME = `Returns all products whose name contains the given search term`;

--- a/src/products/products.controller.ts
+++ b/src/products/products.controller.ts
@@ -15,7 +15,8 @@ import {
   ApiForbiddenResponse,
   ApiInternalServerErrorResponse,
   ApiHeader,
-  ApiQuery
+  ApiQuery,
+  ApiExcludeEndpoint
 } from '@nestjs/swagger';
 import { AuthGuard } from '../auth/auth.guard';
 import { JwtProcessorType } from '../auth/auth.service';
@@ -26,7 +27,8 @@ import { Product } from '../model/product.entity';
 import {
   API_DESC_GET_LATEST_PRODUCTS,
   API_DESC_GET_PRODUCTS,
-  API_DESC_GET_VIEW_PRODUCT
+  API_DESC_GET_VIEW_PRODUCT,
+  API_DESC_SEARCH_PRODUCTS_BY_NAME
 } from './products.controller.api.desc';
 
 @Controller('/api/products')
@@ -34,7 +36,7 @@ import {
 export class ProductsController {
   private readonly logger = new Logger(ProductsController.name);
 
-  constructor(private readonly productsService: ProductsService) {}
+  constructor(private readonly productsService: ProductsService) { }
 
   private parseDate(dateString: string): Date {
     const dateParts = dateString.split('-');
@@ -109,6 +111,29 @@ export class ProductsController {
       throw new BadRequestException('Limit must be positive');
     }
     const products = await this.productsService.findLatest(limit || 3);
+    return products.map((p: Product) => new ProductDto(p));
+  }
+
+  @Get('search')
+  @UseGuards(AuthGuard)
+  @JwtType(JwtProcessorType.RSA)
+  @ApiExcludeEndpoint()
+  @ApiQuery({ name: 'name', example: 'Amethyst', required: true })
+  @ApiOperation({
+    description: API_DESC_SEARCH_PRODUCTS_BY_NAME
+  })
+  @ApiOkResponse({
+    type: ProductDto,
+    isArray: true
+  })
+  async searchProductsByName(
+    @Query('name') name: string
+  ): Promise<ProductDto[]> {
+    if (!name) {
+      throw new BadRequestException('Product name is required');
+    }
+
+    const products = await this.productsService.searchByName(name);
     return products.map((p: Product) => new ProductDto(p));
   }
 

--- a/src/products/products.controller.ts
+++ b/src/products/products.controller.ts
@@ -36,7 +36,7 @@ import {
 export class ProductsController {
   private readonly logger = new Logger(ProductsController.name);
 
-  constructor(private readonly productsService: ProductsService) { }
+  constructor(private readonly productsService: ProductsService) {}
 
   private parseDate(dateString: string): Date {
     const dateParts = dateString.split('-');

--- a/src/products/products.service.ts
+++ b/src/products/products.service.ts
@@ -15,7 +15,7 @@ export class ProductsService {
     @InjectRepository(Product)
     private readonly productsRepository: EntityRepository<Product>,
     private readonly em: EntityManager
-  ) { }
+  ) {}
 
   private sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/products/products.service.ts
+++ b/src/products/products.service.ts
@@ -15,7 +15,7 @@ export class ProductsService {
     @InjectRepository(Product)
     private readonly productsRepository: EntityRepository<Product>,
     private readonly em: EntityManager
-  ) {}
+  ) { }
 
   private sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
@@ -48,6 +48,27 @@ export class ProductsService {
       {},
       { limit, orderBy: { createdAt: 'desc' } }
     );
+  }
+
+  async searchByName(name: string): Promise<Product[]> {
+    this.logger.debug(`Search products by name containing "${name}"`);
+    try {
+      const query = `
+        select *
+        from product
+        where name ilike '%${name}%';
+      `;
+      const rows = await this.em.getConnection().execute<Product[]>(query);
+
+      return rows.map((row: Product) => this.em.map(Product, row));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.error(
+        `Failed to search products by name "${name}": ${message}`,
+        err instanceof Error ? err.stack : undefined
+      );
+      throw err;
+    }
   }
 
   async updateProduct(query: string): Promise<void> {

--- a/src/safe-files/safe-files.controller.ts
+++ b/src/safe-files/safe-files.controller.ts
@@ -12,7 +12,7 @@ import { SafeFilesService, SafeFileResponse } from './safe-files.service';
 @ApiTags('Safe files controller')
 @ApiExcludeController()
 export class SafeFilesController {
-  constructor(private readonly service: SafeFilesService) { }
+  constructor(private readonly service: SafeFilesService) {}
   @Post()
   @ApiOperation({ description: 'Store a new file URL if its host is allowed' })
   @ApiOkResponse({

--- a/src/safe-files/safe-files.controller.ts
+++ b/src/safe-files/safe-files.controller.ts
@@ -1,0 +1,40 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiExcludeController,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags
+} from '@nestjs/swagger';
+import { SafeFilesService, SafeFileResponse } from './safe-files.service';
+
+@Controller('/api/safe-files')
+@ApiTags('Safe files controller')
+@ApiExcludeController()
+export class SafeFilesController {
+  constructor(private readonly service: SafeFilesService) { }
+  @Post()
+  @ApiOperation({ description: 'Store a new file URL if its host is allowed' })
+  @ApiOkResponse({
+    schema: {
+      type: 'object',
+      properties: {
+        file: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            url: { type: 'string' }
+          }
+        },
+        content: { type: 'string' }
+      }
+    }
+  })
+  @ApiBadRequestResponse({ description: 'Untrusted host' })
+  create(
+    @Body('name') name: string,
+    @Body('url') url: string
+  ): Promise<SafeFileResponse> {
+    return this.service.add(name, url);
+  }
+}

--- a/src/safe-files/safe-files.module.ts
+++ b/src/safe-files/safe-files.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { SafeFilesService } from './safe-files.service';
+import { SafeFilesController } from './safe-files.controller';
+
+@Module({
+  providers: [SafeFilesService],
+  controllers: [SafeFilesController]
+})
+export class SafeFilesModule {}

--- a/src/safe-files/safe-files.service.ts
+++ b/src/safe-files/safe-files.service.ts
@@ -1,0 +1,29 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import axios from 'axios';
+
+const ALLOWED_HOSTS = new Set(['filedealer.nexploit.app']);
+
+export interface SafeFileResponse {
+  name: string;
+  url: string;
+  content: string;
+}
+
+@Injectable()
+export class SafeFilesService {
+  async add(name: string, url: string): Promise<SafeFileResponse> {
+    const host = new URL(url).host;
+    if (!ALLOWED_HOSTS.has(host)) {
+      throw new BadRequestException('Untrusted host');
+    }
+    const content = await this.fetchContent(url);
+    return { name, url, content };
+  }
+
+  private async fetchContent(url: string): Promise<string> {
+    const response = await axios.get(url, { responseType: 'text' });
+    return typeof response.data === 'string'
+      ? response.data
+      : JSON.stringify(response.data);
+  }
+}

--- a/src/users/users.controller.swagger.desc.ts
+++ b/src/users/users.controller.swagger.desc.ts
@@ -21,3 +21,7 @@ export const SWAGGER_DESC_UPLOAD_USER_PHOTO = `Uploads user profile photo`;
 export const SWAGGER_DESC_UPDATE_USER_INFO = `Method for updating user details. Vulnerability case: Mass Assignment allows an attacker to modify object properties, which are not supposed to be changed by the user`;
 
 export const SWAGGER_DESC_ADMIN_RIGHTS = `Endpoint for checking admin rights of authenticated user`;
+
+export const SWAGGER_DESC_GET_SELF = `Returns data of the authenticated user`;
+
+export const SWAGGER_DESC_UPDATE_SELF = `Updates all fields of the authenticated user`;

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -33,7 +33,8 @@ import {
   ApiOperation,
   ApiQuery,
   ApiTags,
-  ApiUnauthorizedResponse
+  ApiUnauthorizedResponse,
+  ApiExcludeEndpoint
 } from '@nestjs/swagger';
 import { CreateUserRequest, SignupMode } from './api/CreateUserRequest';
 import { UserDto } from './api/UserDto';
@@ -518,6 +519,7 @@ export class UsersController {
 
   @Get('/me')
   @UseGuards(AuthGuard)
+  @ApiExcludeEndpoint()
   @JwtType(JwtProcessorType.RSA)
   @ApiOperation({
     description: SWAGGER_DESC_GET_SELF
@@ -555,6 +557,7 @@ export class UsersController {
   @Put('/me')
   @UseGuards(AuthGuard)
   @JwtType(JwtProcessorType.RSA)
+  @ApiExcludeEndpoint()
   @SerializeOptions({ groups: [FULL_USER_INFO] })
   @ApiOperation({
     description: SWAGGER_DESC_UPDATE_SELF

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -58,7 +58,9 @@ import {
   SWAGGER_DESC_ADMIN_RIGHTS,
   SWAGGER_DESC_FIND_USERS,
   SWAGGER_DESC_FIND_FULL_USER_INFO,
-  SWAGGER_DESC_DELETE_PHOTO_USER_BY_ID
+  SWAGGER_DESC_DELETE_PHOTO_USER_BY_ID,
+  SWAGGER_DESC_GET_SELF,
+  SWAGGER_DESC_UPDATE_SELF
 } from './users.controller.swagger.desc';
 import { AdminGuard } from './users.guard';
 import { PermissionDto } from './api/PermissionDto';
@@ -512,6 +514,69 @@ export class UsersController {
   })
   getAdminStatus(@Param('email') email: string): Promise<PermissionDto> {
     return this.usersService.getPermissions(email);
+  }
+
+  @Get('/me')
+  @UseGuards(AuthGuard)
+  @JwtType(JwtProcessorType.RSA)
+  @ApiOperation({
+    description: SWAGGER_DESC_GET_SELF
+  })
+  @ApiOkResponse({
+    schema: {
+      type: 'object',
+      properties: {
+        firstName: { type: 'string' },
+        lastName: { type: 'string' },
+        id: { type: 'number' }
+      }
+    },
+    description: 'Returns authenticated user data'
+  })
+  async getAuthenticatedUser(
+    @Req() req: FastifyRequest
+  ): Promise<Pick<UserDto, 'firstName' | 'lastName' | 'id'>> {
+    try {
+      const email = this.originEmail(req);
+      const user = await this.usersService.findByEmail(email);
+      return {
+        firstName: user.firstName,
+        lastName: user.lastName,
+        id: user.id
+      };
+    } catch (err) {
+      throw new HttpException(
+        err.message || 'Internal server error',
+        err.status || 500
+      );
+    }
+  }
+
+  @Put('/me')
+  @UseGuards(AuthGuard)
+  @JwtType(JwtProcessorType.RSA)
+  @SerializeOptions({ groups: [FULL_USER_INFO] })
+  @ApiOperation({
+    description: SWAGGER_DESC_UPDATE_SELF
+  })
+  @ApiOkResponse({
+    type: UserDto,
+    description: 'Returns updated authenticated user'
+  })
+  async updateAuthenticatedUser(
+    @Body() newData: UserDto,
+    @Req() req: FastifyRequest
+  ): Promise<UserDto> {
+    try {
+      const email = this.originEmail(req);
+      const user = await this.usersService.updateUserAll(email, newData);
+      return new UserDto(user);
+    } catch (err) {
+      throw new HttpException(
+        err.message || 'Internal server error',
+        err.status || 500
+      );
+    }
   }
 
   @Put('/one/:email/photo')

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -92,6 +92,19 @@ export class UsersService {
     };
   }
 
+  async updateUserAll(email: string, newData: UserDto): Promise<User> {
+    this.log.debug(`updateUserAll ${email}`);
+    const user = await this.findByEmail(email);
+    const updatedFields = { ...newData };
+    if (newData.password) {
+      updatedFields.password = await hashPassword(newData.password);
+    }
+
+    wrap(user).assign(updatedFields);
+    await this.em.persistAndFlush(user);
+    return user;
+  }
+
   async findByEmail(email: string): Promise<User> {
     this.log.debug(`Called findByEmail ${email}`);
     const user = await this.usersRepository.findOne({ email });


### PR DESCRIPTION
**Summary**
- Added “Hidden Upload” feature (**XSS + File Upload**): client page for image upload with user-supplied filename, live preview (raw insert for SVG), backend endpoint saving to `uploads/hidden` and returning data URLs.
- Introduced “Safe Files” module that only implements **RFI vulnerability**.
- Extended products API **/api/products/search?name** with a new **SQL Injection**.
- Added 2 new endpoints PUT `/api/users/me` and GET `/api/users/me` for BOPLA

All 3 endpoints are excluded from Swagger documentation.

[SET-1953](https://brightsec.atlassian.net/browse/SET-1953)

[SET-1953]: https://brightsec.atlassian.net/browse/SET-1953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ