### PR TITLE
chore(ldap): add url decode ldap query to imitate real server behavior

### DIFF
--- a/src/users/ldap.query.handler.ts
+++ b/src/users/ldap.query.handler.ts
@@ -16,7 +16,14 @@ export class LdapQueryHandler {
   public parseQuery(query: string): string {
     this.log.debug(`query: ${query}`);
 
-    const res = query.match(LdapQueryHandler.PARSER);
+    let res: RegExpMatchArray | null;
+
+    try {
+      res = decodeURIComponent(query).match(LdapQueryHandler.PARSER);
+    } catch (error) {
+      this.log.error(`Failed to decode ldap query: '${query}' error: ${error}`);
+      throw new Error(LdapQueryHandler.LDAP_ERROR_RESPONSE);
+    }
 
     if (!res || res.length != 2 || !res[1]) {
       throw new Error(LdapQueryHandler.LDAP_ERROR_RESPONSE);


### PR DESCRIPTION
According to rfc4515 ldap servers know nothing about url encoding of filter strings. So it is a good assumption that real web application does at least one url decode of the query string. 

set-2027