### PR TITLE
feat(mcp): add more vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1227,11 +1227,14 @@ Full configuration & usage examples can be found in our [demo project](https://g
 
   </details>
 
-- **MCP (Model Context Protocol) Vulnerabilities** - The application exposes an MCP HTTP endpoint at `/api/mcp` that implements the JSON-RPC 2.0 protocol for AI agent tool calling. This endpoint contains multiple vulnerabilities through its exposed tools:
+- **MCP (Model Context Protocol) Vulnerabilities** - The application exposes an MCP HTTP endpoint at `/api/mcp` that implements the JSON-RPC 2.0 protocol for AI agent tool calling. This endpoint contains multiple vulnerabilities through its exposed tools and resources:
 
   - **SQL Injection via count_tool** - The `count_tool` accepts a SQL query parameter and executes it directly against the database without sanitization, similar to the `/api/testimonials/count` endpoint.
   - **Sensitive Data Exposure via config_tool** - The `config_tool` returns application configuration including database credentials, API keys, and cloud storage URLs.
   - **Server-Side Template Injection via render_tool** - The `render_tool` accepts a custom template string that is compiled and executed using the doT template engine, allowing arbitrary code execution.
+  - **Server-Side Request Forgery via fetch_tool** - The `fetch_tool` accepts an arbitrary URL and performs a server-side HTTP request without host, IP range, or protocol restrictions.
+  - **Local File Inclusion via MCP resources/read** - The `resources/read` method accepts `file://` URIs and proxies `/api/file/raw`, allowing arbitrary file reads such as `file:///etc/hosts`.
+  - **Server-Side JavaScript Injection via summarize_tool** - The `summarize_tool` proxies `/api/summarize_cristals` and executes arbitrary JavaScript in server context.
   - **Authentication and Session Management** - The `/api/mcp` endpoint supports optional authentication and per-client session tracking:
 
     - MCP sessions are independent from the regular API authentication/authorization flow.
@@ -1248,8 +1251,10 @@ Full configuration & usage examples can be found in our [demo project](https://g
     - MCP permissions are role-based using the same user model as the HTTP server (`admin` vs regular user).
     - Some tools require authenticated MCP sessions, while others are available without authentication.
     - `config_tool` is admin-only.
+    - `render_tool` responds as `text/event-stream`:
+      `event: message` + `data: <json-rpc-payload>`.
 
-  - **MCP Tool List (Quick Reference)**:
+  - **MCP Tool/Resource List (Quick Reference)**:
 
     _Initialize guest MCP session (required for all non-`initialize` MCP calls):_
 
@@ -1304,7 +1309,77 @@ Full configuration & usage examples can be found in our [demo project](https://g
          }'
        ```
 
-    3. `config_tool` (admin only)  
+    3. `fetch_tool` (public)  
+       Vulnerability: **Server-Side Request Forgery (SSRF)** via arbitrary server-side URL fetch.  
+       Example:
+
+       ```bash
+       curl "${BASE}/api/mcp" -X POST \
+         -H 'Content-Type: application/json' \
+         -H "Mcp-Session-Id: ${MCP_SESSION_ID}" \
+         -d '{
+           "jsonrpc": "2.0",
+           "method": "tools/call",
+           "params": {
+             "name": "fetch_tool",
+             "arguments": {
+               "url": "http://127.0.0.1:3000/api/config"
+             }
+           },
+           "id": 4
+         }'
+       ```
+
+    4. `resources/list` + `resources/read` (public)  
+       Vulnerability: **Local File Inclusion (LFI)** via `file://` URI read from `/api/file/raw`.  
+       Example:
+
+       ```bash
+       curl "${BASE}/api/mcp" -X POST \
+         -H 'Content-Type: application/json' \
+         -H "Mcp-Session-Id: ${MCP_SESSION_ID}" \
+         -d '{
+           "jsonrpc": "2.0",
+           "method": "resources/list",
+           "id": 5
+         }'
+
+       curl "${BASE}/api/mcp" -X POST \
+         -H 'Content-Type: application/json' \
+         -H "Mcp-Session-Id: ${MCP_SESSION_ID}" \
+         -d '{
+           "jsonrpc": "2.0",
+           "method": "resources/read",
+           "params": {
+             "uri": "file:///etc/hosts"
+           },
+           "id": 6
+         }'
+       ```
+
+    5. `summarize_tool` (public)  
+       Vulnerability: **Server-Side JavaScript Injection (SSJI)** via dynamic code execution.  
+       Example:
+
+       ```bash
+       curl "${BASE}/api/mcp" -X POST \
+         -H 'Content-Type: application/json' \
+         -H "Mcp-Session-Id: ${MCP_SESSION_ID}" \
+         -d '{
+           "jsonrpc": "2.0",
+           "method": "tools/call",
+           "params": {
+            "name": "summarize_tool",
+            "arguments": {
+              "numbers": [1, 2, 3],
+              "summarize_expression": "global.process.mainModule.require('\''os'\'').hostname()"
+            }
+          },
+          "id": 7
+         }'
+       ```
+
+    6. `config_tool` (admin only)  
        Vulnerability: **Sensitive Data Exposure** (returns app configuration including secrets when allowed).  
        Example (admin-authenticated MCP session):
 
@@ -1341,7 +1416,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
 
   _Note: Always call `initialize` first. After that, send `Mcp-Session-Id` on every MCP request. Authenticated and unauthenticated sessions are both supported._
 
-  1. **Initialize MCP session and list tools**:
+  1. **Initialize MCP session and list tools/resources**:
 
   ```bash
   BASE='https://brokencrystals.com'
@@ -1354,6 +1429,11 @@ Full configuration & usage examples can be found in our [demo project](https://g
     -H 'Content-Type: application/json' \
     -H "Mcp-Session-Id: ${MCP_SESSION_ID}" \
     -d '{"jsonrpc":"2.0","method":"tools/list","id":2}'
+
+  curl "${BASE}/api/mcp" -X POST \
+    -H 'Content-Type: application/json' \
+    -H "Mcp-Session-Id: ${MCP_SESSION_ID}" \
+    -d '{"jsonrpc":"2.0","method":"resources/list","id":3}'
   ```
 
   2. **SQL Injection via count_tool**:
@@ -1432,7 +1512,68 @@ Full configuration & usage examples can be found in our [demo project](https://g
      }
      ```
 
-  4. **Server-Side Template Injection via render_tool**:
+  4. **Server-Side Request Forgery via fetch_tool**:
+
+     ```bash
+     curl "${BASE}/api/mcp" -X POST \
+       -H 'Content-Type: application/json' \
+       -H "Mcp-Session-Id: ${MCP_SESSION_ID}" \
+       -d '{
+         "jsonrpc": "2.0",
+         "method": "tools/call",
+         "params": {
+           "name": "fetch_tool",
+           "arguments": {
+             "url": "http://127.0.0.1:3000/api/config"
+           }
+         },
+         "id": 5
+       }'
+     ```
+
+     This payload forces the MCP server to request an internal endpoint from its own network context.
+
+  5. **Local File Inclusion via resources/read**:
+
+     ```bash
+     curl "${BASE}/api/mcp" -X POST \
+       -H 'Content-Type: application/json' \
+       -H "Mcp-Session-Id: ${MCP_SESSION_ID}" \
+       -d '{
+         "jsonrpc": "2.0",
+         "method": "resources/read",
+         "params": {
+           "uri": "file:///etc/hosts"
+         },
+         "id": 6
+       }'
+     ```
+
+     This payload reads local server files through the `/api/file/raw` proxy using a `file://` URI.
+
+  6. **Server-Side JavaScript Injection via summarize_tool**:
+
+     ```bash
+     curl "${BASE}/api/mcp" -X POST \
+       -H 'Content-Type: application/json' \
+       -H "Mcp-Session-Id: ${MCP_SESSION_ID}" \
+       -d '{
+         "jsonrpc": "2.0",
+         "method": "tools/call",
+         "params": {
+           "name": "summarize_tool",
+           "arguments": {
+             "numbers": [1, 2, 3],
+             "summarize_expression": "global.process.mainModule.require('\''os'\'').hostname()"
+           }
+         },
+         "id": 7
+       }'
+     ```
+
+     This payload executes JavaScript directly on the server.
+
+  7. **Server-Side Template Injection via render_tool**:
 
      ```bash
      curl "${BASE}/api/mcp" -X POST \
@@ -1448,7 +1589,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
              "template": "{{= global.process.mainModule.require('\''child_process'\'').execSync('\''ls -la'\'') }}"
            }
          },
-         "id": 5
+         "id": 8
        }'
      ```
 

--- a/README.md
+++ b/README.md
@@ -1232,7 +1232,6 @@ Full configuration & usage examples can be found in our [demo project](https://g
   - **SQL Injection via count_tool** - The `count_tool` accepts a SQL query parameter and executes it directly against the database without sanitization, similar to the `/api/testimonials/count` endpoint.
   - **Sensitive Data Exposure via config_tool** - The `config_tool` returns application configuration including database credentials, API keys, and cloud storage URLs.
   - **Server-Side Template Injection via render_tool** - The `render_tool` accepts a custom template string that is compiled and executed using the doT template engine, allowing arbitrary code execution.
-  - **Server-Side Request Forgery via fetch_tool** - The `fetch_tool` accepts an arbitrary URL and performs a server-side HTTP request without host, IP range, or protocol restrictions.
   - **Local File Inclusion via MCP resources/read** - The `resources/read` method accepts `file://` URIs and proxies `/api/file/raw`, allowing arbitrary file reads such as `file:///etc/hosts`.
   - **Server-Side JavaScript Injection via process_numbers_tool** - The `process_numbers_tool` proxies `/api/process_numbers` and executes arbitrary JavaScript from the `processing_expression` expression in server context.
   - **Authentication and Session Management** - The `/api/mcp` endpoint supports optional authentication and per-client session tracking:
@@ -1309,28 +1308,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
          }'
        ```
 
-    3. `fetch_tool` (public)  
-       Vulnerability: **Server-Side Request Forgery (SSRF)** via arbitrary server-side URL fetch.  
-       Example:
-
-       ```bash
-       curl "${BASE}/api/mcp" -X POST \
-         -H 'Content-Type: application/json' \
-         -H "Mcp-Session-Id: ${MCP_SESSION_ID}" \
-         -d '{
-           "jsonrpc": "2.0",
-           "method": "tools/call",
-           "params": {
-             "name": "fetch_tool",
-             "arguments": {
-               "url": "http://127.0.0.1:3000/api/config"
-             }
-           },
-           "id": 4
-         }'
-       ```
-
-    4. `resources/list` + `resources/read` (public)  
+    3. `resources/list` + `resources/read` (public)  
        Vulnerability: **Local File Inclusion (LFI)** via `file://` URI read from `/api/file/raw`.  
        Example:
 
@@ -1341,7 +1319,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
          -d '{
            "jsonrpc": "2.0",
            "method": "resources/list",
-           "id": 5
+           "id": 4
          }'
 
        curl "${BASE}/api/mcp" -X POST \
@@ -1353,11 +1331,11 @@ Full configuration & usage examples can be found in our [demo project](https://g
            "params": {
              "uri": "file:///etc/hosts"
            },
-           "id": 6
+           "id": 5
          }'
        ```
 
-    5. `process_numbers_tool` (public)  
+    4. `process_numbers_tool` (public)  
        Vulnerability: **Server-Side JavaScript Injection (SSJI)** via dynamic code execution.  
        Example:
 
@@ -1375,11 +1353,11 @@ Full configuration & usage examples can be found in our [demo project](https://g
               "processing_expression": "numbers.reduce((acc, num) => acc + num, 0)"
             }
           },
-          "id": 7
+          "id": 6
          }'
        ```
 
-    6. `config_tool` (admin only)  
+    5. `config_tool` (admin only)  
        Vulnerability: **Sensitive Data Exposure** (returns app configuration including secrets when allowed).  
        Example (admin-authenticated MCP session):
 
@@ -1512,28 +1490,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
      }
      ```
 
-  4. **Server-Side Request Forgery via fetch_tool**:
-
-     ```bash
-     curl "${BASE}/api/mcp" -X POST \
-       -H 'Content-Type: application/json' \
-       -H "Mcp-Session-Id: ${MCP_SESSION_ID}" \
-       -d '{
-         "jsonrpc": "2.0",
-         "method": "tools/call",
-         "params": {
-           "name": "fetch_tool",
-           "arguments": {
-             "url": "http://127.0.0.1:3000/api/config"
-           }
-         },
-         "id": 5
-       }'
-     ```
-
-     This payload forces the MCP server to request an internal endpoint from its own network context.
-
-  5. **Local File Inclusion via resources/read**:
+  4. **Local File Inclusion via resources/read**:
 
      ```bash
      curl "${BASE}/api/mcp" -X POST \
@@ -1545,13 +1502,13 @@ Full configuration & usage examples can be found in our [demo project](https://g
          "params": {
            "uri": "file:///etc/hosts"
          },
-         "id": 6
+         "id": 5
        }'
      ```
 
      This payload reads local server files through the `/api/file/raw` proxy using a `file://` URI.
 
-  6. **Server-Side JavaScript Injection via process_numbers_tool**:
+  5. **Server-Side JavaScript Injection via process_numbers_tool**:
 
      ```bash
      curl "${BASE}/api/mcp" -X POST \
@@ -1567,13 +1524,13 @@ Full configuration & usage examples can be found in our [demo project](https://g
              "processing_expression": "numbers.reduce((acc, num) => acc + num, 0)"
            }
          },
-         "id": 7
+         "id": 6
        }'
      ```
 
      This payload executes JavaScript directly on the server.
 
-  7. **Server-Side Template Injection via render_tool**:
+  6. **Server-Side Template Injection via render_tool**:
 
      ```bash
      curl "${BASE}/api/mcp" -X POST \

--- a/README.md
+++ b/README.md
@@ -1234,7 +1234,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
   - **Server-Side Template Injection via render_tool** - The `render_tool` accepts a custom template string that is compiled and executed using the doT template engine, allowing arbitrary code execution.
   - **Server-Side Request Forgery via fetch_tool** - The `fetch_tool` accepts an arbitrary URL and performs a server-side HTTP request without host, IP range, or protocol restrictions.
   - **Local File Inclusion via MCP resources/read** - The `resources/read` method accepts `file://` URIs and proxies `/api/file/raw`, allowing arbitrary file reads such as `file:///etc/hosts`.
-  - **Server-Side JavaScript Injection via summarize_tool** - The `summarize_tool` proxies `/api/summarize_cristals` and executes arbitrary JavaScript in server context.
+  - **Server-Side JavaScript Injection via process_numbers_tool** - The `process_numbers_tool` proxies `/api/process_numbers` and executes arbitrary JavaScript from the `processing_expression` expression in server context.
   - **Authentication and Session Management** - The `/api/mcp` endpoint supports optional authentication and per-client session tracking:
 
     - MCP sessions are independent from the regular API authentication/authorization flow.
@@ -1357,7 +1357,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
          }'
        ```
 
-    5. `summarize_tool` (public)  
+    5. `process_numbers_tool` (public)  
        Vulnerability: **Server-Side JavaScript Injection (SSJI)** via dynamic code execution.  
        Example:
 
@@ -1369,10 +1369,10 @@ Full configuration & usage examples can be found in our [demo project](https://g
            "jsonrpc": "2.0",
            "method": "tools/call",
            "params": {
-            "name": "summarize_tool",
+            "name": "process_numbers_tool",
             "arguments": {
               "numbers": [1, 2, 3],
-              "summarize_expression": "global.process.mainModule.require('\''os'\'').hostname()"
+              "processing_expression": "numbers.reduce((acc, num) => acc + num, 0)"
             }
           },
           "id": 7
@@ -1551,7 +1551,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
 
      This payload reads local server files through the `/api/file/raw` proxy using a `file://` URI.
 
-  6. **Server-Side JavaScript Injection via summarize_tool**:
+  6. **Server-Side JavaScript Injection via process_numbers_tool**:
 
      ```bash
      curl "${BASE}/api/mcp" -X POST \
@@ -1561,10 +1561,10 @@ Full configuration & usage examples can be found in our [demo project](https://g
          "jsonrpc": "2.0",
          "method": "tools/call",
          "params": {
-           "name": "summarize_tool",
+           "name": "process_numbers_tool",
            "arguments": {
              "numbers": [1, 2, 3],
-             "summarize_expression": "global.process.mainModule.require('\''os'\'').hostname()"
+             "processing_expression": "numbers.reduce((acc, num) => acc + num, 0)"
            }
          },
          "id": 7

--- a/src/app.controller.swagger.desc.ts
+++ b/src/app.controller.swagger.desc.ts
@@ -8,6 +8,8 @@ export const API_DESC_OPTIONS_REQUEST = `Returns the list of supported operation
 
 export const API_DESC_LAUNCH_COMMAND = `Launches system command on server`;
 
+export const API_DESC_SUMMARIZE_CRISTALS_REQUEST = `Summarizes crystal numbers provided by the client using a required summarize_expression`;
+
 export const API_DESC_CONFIG_SERVER = `Returns server configuration to the client`;
 
 export const SWAGGER_DESC_SECRETS = `Returns server secrets. Shhhh 🤫`;

--- a/src/app.controller.swagger.desc.ts
+++ b/src/app.controller.swagger.desc.ts
@@ -8,7 +8,7 @@ export const API_DESC_OPTIONS_REQUEST = `Returns the list of supported operation
 
 export const API_DESC_LAUNCH_COMMAND = `Launches system command on server`;
 
-export const API_DESC_SUMMARIZE_CRISTALS_REQUEST = `Summarizes crystal numbers provided by the client using a required summarize_expression`;
+export const API_DESC_PROCESS_NUMBERS_REQUEST = `Processes crystal numbers provided by the client using a required processing_expression`;
 
 export const API_DESC_CONFIG_SERVER = `Returns server configuration to the client`;
 

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -5,6 +5,7 @@ import {
   Get,
   Header,
   HttpException,
+  HttpCode,
   InternalServerErrorException,
   Logger,
   Options,
@@ -12,6 +13,7 @@ import {
   Post,
   Query,
   Redirect,
+  Res,
   SerializeOptions,
   UseGuards,
   UseInterceptors,
@@ -33,6 +35,7 @@ import {
   ApiTags
 } from '@nestjs/swagger';
 import * as dotT from 'dot';
+import { FastifyReply } from 'fastify';
 import { parseXml } from 'libxmljs';
 import { AppConfig } from './app.config.api';
 import {
@@ -41,6 +44,7 @@ import {
   API_DESC_OPTIONS_REQUEST,
   API_DESC_REDIRECT_REQUEST,
   API_DESC_RENDER_REQUEST,
+  API_DESC_SUMMARIZE_CRISTALS_REQUEST,
   API_DESC_XML_METADATA,
   SWAGGER_DESC_SECRETS,
   SWAGGER_DESC_NESTED_JSON
@@ -157,6 +161,85 @@ export class AppController {
         error: err.message || err,
         location: __filename
       });
+    }
+  }
+
+  @Post('summarize_cristals')
+  @HttpCode(200)
+  @ApiProduces('text/plain')
+  @ApiConsumes('application/json')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        numbers: {
+          type: 'array',
+          items: { type: 'number' },
+          example: [1, 2, 3, 4]
+        },
+        summarize_expression: {
+          type: 'string',
+          example: 'numbers.reduce((acc, num) => acc + num, 0)'
+        }
+      },
+      required: ['numbers', 'summarize_expression']
+    }
+  })
+  @ApiOperation({
+    description: API_DESC_SUMMARIZE_CRISTALS_REQUEST
+  })
+  @ApiOkResponse({
+    type: String,
+    description: 'Summarized value'
+  })
+  @ApiInternalServerErrorResponse({
+    schema: {
+      type: 'object',
+      properties: { location: { type: 'string' } }
+    }
+  })
+  async summarizeCristals(
+    @Body()
+    payload: { numbers: number[]; summarize_expression: string },
+    @Res() res: FastifyReply
+  ): Promise<void> {
+    const numbers = Array.isArray(payload?.numbers) ? payload.numbers : [];
+    const summarizeExpression =
+      typeof payload?.summarize_expression === 'string' &&
+      payload.summarize_expression.trim().length > 0
+        ? payload.summarize_expression
+        : 'numbers.reduce((acc, num) => acc + num, 0)';
+
+    // expose both names used by exploiter payloads
+    const response = res;
+
+    this.logger.debug(`Summarizing crystals with ${numbers.length} values`);
+
+    try {
+      const result = eval(summarizeExpression);
+
+      // SSJI payload may already end the response
+      if (response.sent || response.raw.writableEnded) {
+        return;
+      }
+
+      if (typeof result === 'string') {
+        response.status(200).type('text/plain').send(result);
+        return;
+      }
+
+      response
+        .status(200)
+        .type('application/json')
+        .send(JSON.stringify(result));
+    } catch (err: unknown) {
+      if (!response.sent && !response.raw.writableEnded) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        throw new InternalServerErrorException({
+          error: errorMessage,
+          location: __filename
+        });
+      }
     }
   }
 

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -44,7 +44,7 @@ import {
   API_DESC_OPTIONS_REQUEST,
   API_DESC_REDIRECT_REQUEST,
   API_DESC_RENDER_REQUEST,
-  API_DESC_SUMMARIZE_CRISTALS_REQUEST,
+  API_DESC_PROCESS_NUMBERS_REQUEST,
   API_DESC_XML_METADATA,
   SWAGGER_DESC_SECRETS,
   SWAGGER_DESC_NESTED_JSON
@@ -164,7 +164,7 @@ export class AppController {
     }
   }
 
-  @Post('summarize_cristals')
+  @Post('process_numbers')
   @HttpCode(200)
   @ApiProduces('text/plain')
   @ApiConsumes('application/json')
@@ -177,16 +177,16 @@ export class AppController {
           items: { type: 'number' },
           example: [1, 2, 3, 4]
         },
-        summarize_expression: {
+        processing_expression: {
           type: 'string',
           example: 'numbers.reduce((acc, num) => acc + num, 0)'
         }
       },
-      required: ['numbers', 'summarize_expression']
+      required: ['numbers', 'processing_expression']
     }
   })
   @ApiOperation({
-    description: API_DESC_SUMMARIZE_CRISTALS_REQUEST
+    description: API_DESC_PROCESS_NUMBERS_REQUEST
   })
   @ApiOkResponse({
     type: String,
@@ -198,25 +198,25 @@ export class AppController {
       properties: { location: { type: 'string' } }
     }
   })
-  async summarizeCristals(
+  async processNumbers(
     @Body()
-    payload: { numbers: number[]; summarize_expression: string },
+    payload: { numbers: number[]; processing_expression: string },
     @Res() res: FastifyReply
   ): Promise<void> {
     const numbers = Array.isArray(payload?.numbers) ? payload.numbers : [];
-    const summarizeExpression =
-      typeof payload?.summarize_expression === 'string' &&
-      payload.summarize_expression.trim().length > 0
-        ? payload.summarize_expression
+    const processNumbersExpression =
+      typeof payload?.processing_expression === 'string' &&
+      payload.processing_expression.trim().length > 0
+        ? payload.processing_expression
         : 'numbers.reduce((acc, num) => acc + num, 0)';
 
     // expose both names used by exploiter payloads
     const response = res;
 
-    this.logger.debug(`Summarizing crystals with ${numbers.length} values`);
+    this.logger.debug(`Processing crystals with ${numbers.length} values`);
 
     try {
-      const result = eval(summarizeExpression);
+      const result = eval(processNumbersExpression);
 
       // SSJI payload may already end the response
       if (response.sent || response.raw.writableEnded) {

--- a/src/mcp/api/mcp.types.ts
+++ b/src/mcp/api/mcp.types.ts
@@ -125,12 +125,6 @@ export interface RenderToolInput {
   template?: string;
 }
 
-export interface FetchToolInput {
-  url: string;
-  method?: string;
-  body?: string;
-}
-
 export interface ProcessNumbersToolInput {
   numbers: number[];
   processing_expression: string;
@@ -176,28 +170,6 @@ export function isRenderToolInput(args: unknown): args is RenderToolInput {
   if ('template' in obj && typeof obj.template !== 'string') {
     return false;
   }
-  return true;
-}
-
-export function isFetchToolInput(args: unknown): args is FetchToolInput {
-  if (typeof args !== 'object' || args === null) {
-    return false;
-  }
-
-  const obj = args as Record<string, unknown>;
-
-  if (typeof obj.url !== 'string' || !obj.url.trim().length) {
-    return false;
-  }
-
-  if ('method' in obj && typeof obj.method !== 'string') {
-    return false;
-  }
-
-  if ('body' in obj && typeof obj.body !== 'string') {
-    return false;
-  }
-
   return true;
 }
 

--- a/src/mcp/api/mcp.types.ts
+++ b/src/mcp/api/mcp.types.ts
@@ -59,6 +59,7 @@ export interface McpInitializeResult {
   protocolVersion: string;
   capabilities: {
     tools: Record<string, never>;
+    resources?: Record<string, never>;
   };
   serverInfo: McpServerInfo;
   session?: McpSessionInfo;
@@ -83,6 +84,25 @@ export interface McpToolCallParams {
   arguments?: Record<string, unknown>;
 }
 
+export interface McpResource {
+  uri: string;
+  name: string;
+  description?: string;
+  mimeType?: string;
+}
+
+export interface McpResourceReadParams {
+  uri: string;
+}
+
+export interface McpResourceReadResult {
+  contents: Array<{
+    uri: string;
+    mimeType?: string;
+    text: string;
+  }>;
+}
+
 export interface McpToolResult {
   content: Array<{
     type: string;
@@ -103,6 +123,17 @@ export interface ConfigToolInput {
 export interface RenderToolInput {
   numbers: number[];
   template?: string;
+}
+
+export interface FetchToolInput {
+  url: string;
+  method?: string;
+  body?: string;
+}
+
+export interface SummarizeToolInput {
+  numbers: number[];
+  summarize_expression: string;
 }
 
 // Type guards for runtime validation
@@ -143,6 +174,61 @@ export function isRenderToolInput(args: unknown): args is RenderToolInput {
     return false;
   }
   if ('template' in obj && typeof obj.template !== 'string') {
+    return false;
+  }
+  return true;
+}
+
+export function isFetchToolInput(args: unknown): args is FetchToolInput {
+  if (typeof args !== 'object' || args === null) {
+    return false;
+  }
+
+  const obj = args as Record<string, unknown>;
+
+  if (typeof obj.url !== 'string' || !obj.url.trim().length) {
+    return false;
+  }
+
+  if ('method' in obj && typeof obj.method !== 'string') {
+    return false;
+  }
+
+  if ('body' in obj && typeof obj.body !== 'string') {
+    return false;
+  }
+
+  return true;
+}
+
+export function isMcpResourceReadParams(
+  params: unknown
+): params is McpResourceReadParams {
+  if (typeof params !== 'object' || params === null) {
+    return false;
+  }
+  const obj = params as Record<string, unknown>;
+  return typeof obj.uri === 'string' && obj.uri.trim().length > 0;
+}
+
+export function isSummarizeToolInput(
+  args: unknown
+): args is SummarizeToolInput {
+  if (typeof args !== 'object' || args === null) {
+    return false;
+  }
+
+  const obj = args as Record<string, unknown>;
+  if (!Array.isArray(obj.numbers)) {
+    return false;
+  }
+  if (!obj.numbers.every((n: unknown) => typeof n === 'number')) {
+    return false;
+  }
+  if (typeof obj.summarize_expression !== 'string') {
+    return false;
+  }
+  if (!obj.summarize_expression.trim().length) {
     return false;
   }
   return true;

--- a/src/mcp/api/mcp.types.ts
+++ b/src/mcp/api/mcp.types.ts
@@ -131,9 +131,9 @@ export interface FetchToolInput {
   body?: string;
 }
 
-export interface SummarizeToolInput {
+export interface ProcessNumbersToolInput {
   numbers: number[];
-  summarize_expression: string;
+  processing_expression: string;
 }
 
 // Type guards for runtime validation
@@ -211,9 +211,9 @@ export function isMcpResourceReadParams(
   return typeof obj.uri === 'string' && obj.uri.trim().length > 0;
 }
 
-export function isSummarizeToolInput(
+export function isProcessNumbersToolInput(
   args: unknown
-): args is SummarizeToolInput {
+): args is ProcessNumbersToolInput {
   if (typeof args !== 'object' || args === null) {
     return false;
   }
@@ -225,10 +225,10 @@ export function isSummarizeToolInput(
   if (!obj.numbers.every((n: unknown) => typeof n === 'number')) {
     return false;
   }
-  if (typeof obj.summarize_expression !== 'string') {
+  if (typeof obj.processing_expression !== 'string') {
     return false;
   }
-  if (!obj.summarize_expression.trim().length) {
+  if (!obj.processing_expression.trim().length) {
     return false;
   }
   return true;

--- a/src/mcp/mcp.controller.swagger.desc.ts
+++ b/src/mcp/mcp.controller.swagger.desc.ts
@@ -31,7 +31,6 @@ Available tools:
 - count_tool: Count testimonials using SQL query
 - config_tool: Get application configuration (admin only)
 - render_tool: Sum numbers and render result (response is text/event-stream)
-- fetch_tool: Fetch arbitrary URLs from the server side
 - process_numbers_tool: Process numbers via /api/process_numbers (requires numbers and processing_expression)
 
 Available resources:

--- a/src/mcp/mcp.controller.swagger.desc.ts
+++ b/src/mcp/mcp.controller.swagger.desc.ts
@@ -32,7 +32,7 @@ Available tools:
 - config_tool: Get application configuration (admin only)
 - render_tool: Sum numbers and render result (response is text/event-stream)
 - fetch_tool: Fetch arbitrary URLs from the server side
-- summarize_tool: Summarize numbers via /api/summarize_cristals (requires numbers and summarize_expression)
+- process_numbers_tool: Process numbers via /api/process_numbers (requires numbers and processing_expression)
 
 Available resources:
 - file:///: Read local server files via /api/file/raw proxy

--- a/src/mcp/mcp.controller.swagger.desc.ts
+++ b/src/mcp/mcp.controller.swagger.desc.ts
@@ -23,10 +23,17 @@ Supported methods:
 - initialize: Establish a new MCP session
 - tools/list: List available tools
 - tools/call: Execute a tool with provided arguments
+- resources/list: List available resources
+- resources/read: Read resource contents by URI
 - DELETE /api/mcp: Explicitly terminate an MCP session
 
 Available tools:
 - count_tool: Count testimonials using SQL query
 - config_tool: Get application configuration (admin only)
-- render_tool: Sum numbers and render result
+- render_tool: Sum numbers and render result (response is text/event-stream)
+- fetch_tool: Fetch arbitrary URLs from the server side
+- summarize_tool: Summarize numbers via /api/summarize_cristals (requires numbers and summarize_expression)
+
+Available resources:
+- file:///: Read local server files via /api/file/raw proxy
 `;

--- a/src/mcp/mcp.controller.ts
+++ b/src/mcp/mcp.controller.ts
@@ -134,26 +134,12 @@ export class McpController {
           id: 5
         }
       },
-      call_fetch_tool: {
-        summary: 'Call fetch_tool',
-        value: {
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'fetch_tool',
-            arguments: {
-              url: 'http://127.0.0.1:3000/api/config'
-            }
-          },
-          id: 6
-        }
-      },
       list_resources: {
         summary: 'List resources',
         value: {
           jsonrpc: '2.0',
           method: 'resources/list',
-          id: 7
+          id: 6
         }
       },
       read_resource: {
@@ -164,7 +150,7 @@ export class McpController {
           params: {
             uri: 'file:///etc/hosts'
           },
-          id: 8
+          id: 7
         }
       },
       call_process_numbers_tool: {
@@ -180,7 +166,7 @@ export class McpController {
                 'numbers.reduce((acc, num) => acc + num, 0)'
             }
           },
-          id: 9
+          id: 8
         }
       }
     }

--- a/src/mcp/mcp.controller.ts
+++ b/src/mcp/mcp.controller.ts
@@ -167,16 +167,17 @@ export class McpController {
           id: 8
         }
       },
-      call_summarize_tool: {
-        summary: 'Call summarize_tool',
+      call_process_numbers_tool: {
+        summary: 'Call process_numbers_tool',
         value: {
           jsonrpc: '2.0',
           method: 'tools/call',
           params: {
-            name: 'summarize_tool',
+            name: 'process_numbers_tool',
             arguments: {
               numbers: [1, 2, 3, 4],
-              summarize_expression: 'numbers.reduce((acc, num) => acc + num, 0)'
+              processing_expression:
+                'numbers.reduce((acc, num) => acc + num, 0)'
             }
           },
           id: 9

--- a/src/mcp/mcp.controller.ts
+++ b/src/mcp/mcp.controller.ts
@@ -3,7 +3,6 @@ import {
   Body,
   Controller,
   Delete,
-  Header,
   HttpCode,
   Logger,
   NotFoundException,
@@ -22,6 +21,7 @@ import {
 } from '@nestjs/swagger';
 import { FastifyReply, FastifyRequest } from 'fastify';
 import {
+  isMcpResourceReadParams,
   McpInitializeResult,
   McpRequest,
   McpResponse,
@@ -41,6 +41,7 @@ interface SessionValidationResult {
 @ApiTags('MCP Controller')
 export class McpController {
   private static readonly MCP_SESSION_ID_HEADER = 'Mcp-Session-Id';
+  private static readonly EVENT_STREAM_TOOLS = new Set<string>(['render_tool']);
 
   private readonly logger = new Logger(McpController.name);
 
@@ -53,7 +54,7 @@ export class McpController {
   @Post()
   @HttpCode(200)
   @ApiConsumes('application/json')
-  @ApiProduces('application/json')
+  @ApiProduces('application/json', 'text/event-stream')
   @ApiOperation({
     description: API_DESC_MCP_ENDPOINT
   })
@@ -132,6 +133,54 @@ export class McpController {
           },
           id: 5
         }
+      },
+      call_fetch_tool: {
+        summary: 'Call fetch_tool',
+        value: {
+          jsonrpc: '2.0',
+          method: 'tools/call',
+          params: {
+            name: 'fetch_tool',
+            arguments: {
+              url: 'http://127.0.0.1:3000/api/config'
+            }
+          },
+          id: 6
+        }
+      },
+      list_resources: {
+        summary: 'List resources',
+        value: {
+          jsonrpc: '2.0',
+          method: 'resources/list',
+          id: 7
+        }
+      },
+      read_resource: {
+        summary: 'Read resource',
+        value: {
+          jsonrpc: '2.0',
+          method: 'resources/read',
+          params: {
+            uri: 'file:///etc/hosts'
+          },
+          id: 8
+        }
+      },
+      call_summarize_tool: {
+        summary: 'Call summarize_tool',
+        value: {
+          jsonrpc: '2.0',
+          method: 'tools/call',
+          params: {
+            name: 'summarize_tool',
+            arguments: {
+              numbers: [1, 2, 3, 4],
+              summarize_expression: 'numbers.reduce((acc, num) => acc + num, 0)'
+            }
+          },
+          id: 9
+        }
       }
     }
   })
@@ -139,12 +188,11 @@ export class McpController {
     type: McpResponse,
     description: 'MCP JSON-RPC response'
   })
-  @Header('content-type', 'application/json')
   async handleMcpRequest(
     @Body() request: McpRequest,
     @Req() req: FastifyRequest,
     @Res({ passthrough: true }) res: FastifyReply
-  ): Promise<McpResponse> {
+  ): Promise<McpResponse | string> {
     this.logger.debug(`MCP Request: ${JSON.stringify(request)}`);
 
     if (request.jsonrpc !== '2.0') {
@@ -180,7 +228,13 @@ export class McpController {
           return this.handleToolsList(request);
 
         case 'tools/call':
-          return await this.handleToolsCall(request, session);
+          return await this.handleToolsCall(request, session, res);
+
+        case 'resources/list':
+          return this.handleResourcesList(request);
+
+        case 'resources/read':
+          return await this.handleResourcesRead(request, session);
 
         default:
           return this.rpcError(
@@ -240,10 +294,55 @@ export class McpController {
     };
   }
 
-  private async handleToolsCall(
+  private handleResourcesList(request: McpRequest): McpResponse {
+    const resources = this.mcpService.getResources();
+
+    return {
+      jsonrpc: '2.0',
+      result: {
+        resources
+      },
+      id: request.id
+    };
+  }
+
+  private async handleResourcesRead(
     request: McpRequest,
     session: McpSessionState
   ): Promise<McpResponse> {
+    const params = request.params;
+    if (!isMcpResourceReadParams(params)) {
+      return this.rpcError(
+        request,
+        -32602,
+        'Invalid params: resources/read requires a "uri" string parameter'
+      );
+    }
+
+    try {
+      const result = await this.mcpService.readResource(params, {
+        authorizationHeader: session.authorizationHeader
+      });
+
+      return {
+        jsonrpc: '2.0',
+        result,
+        id: request.id
+      };
+    } catch (error) {
+      return this.rpcError(
+        request,
+        -32603,
+        `Internal error: ${(error as Error).message}`
+      );
+    }
+  }
+
+  private async handleToolsCall(
+    request: McpRequest,
+    session: McpSessionState,
+    res: FastifyReply
+  ): Promise<McpResponse | string> {
     const params = request.params as unknown as McpToolCallParams;
 
     if (!params?.name) {
@@ -254,23 +353,31 @@ export class McpController {
       );
     }
 
+    const shouldStream = this.isEventStreamTool(params.name);
+
     if (!this.isToolAllowedForSession(params.name, session)) {
-      return this.rpcError(
+      const errorResponse = this.rpcError(
         request,
         -32001,
         this.buildToolAccessError(params.name, session)
       );
+
+      return shouldStream
+        ? this.toEventStreamMessage(res, errorResponse)
+        : errorResponse;
     }
 
     const result = await this.mcpService.callTool(params, {
       authorizationHeader: session.authorizationHeader
     });
 
-    return {
+    const response: McpResponse = {
       jsonrpc: '2.0',
       result,
       id: request.id
     };
+
+    return shouldStream ? this.toEventStreamMessage(res, response) : response;
   }
 
   private rpcError(
@@ -302,7 +409,8 @@ export class McpController {
       const result: McpInitializeResult = {
         protocolVersion: '2024-11-05',
         capabilities: {
-          tools: {}
+          tools: {},
+          resources: {}
         },
         serverInfo: {
           name: 'brokencrystals-mcp',
@@ -383,6 +491,20 @@ export class McpController {
     }
 
     return /^[\x21-\x7E]+$/.test(trimmed) ? trimmed : undefined;
+  }
+
+  private isEventStreamTool(toolName: string): boolean {
+    return McpController.EVENT_STREAM_TOOLS.has(toolName);
+  }
+
+  private toEventStreamMessage(
+    res: FastifyReply,
+    payload: McpResponse
+  ): string {
+    res.header('content-type', 'text/event-stream; charset=utf-8');
+    res.header('cache-control', 'no-cache');
+    res.header('connection', 'keep-alive');
+    return `event: message\ndata: ${JSON.stringify(payload)}\n\n`;
   }
 
   private isToolAllowedForSession(

--- a/src/mcp/mcp.module.ts
+++ b/src/mcp/mcp.module.ts
@@ -4,6 +4,7 @@ import { McpService } from './mcp.service';
 import { UsersModule } from '../users/users.module';
 import { AuthModule } from '../auth/auth.module';
 import { McpAuthService } from './mcp.auth.service';
+import { McpResourceExecutorService } from './mcp.resource-executor.service';
 import { McpSessionService } from './mcp.session.service';
 import { McpToolExecutorService } from './mcp.tool-executor.service';
 
@@ -14,7 +15,8 @@ import { McpToolExecutorService } from './mcp.tool-executor.service';
     McpService,
     McpAuthService,
     McpSessionService,
-    McpToolExecutorService
+    McpToolExecutorService,
+    McpResourceExecutorService
   ]
 })
 export class McpModule {}

--- a/src/mcp/mcp.proxy-support.ts
+++ b/src/mcp/mcp.proxy-support.ts
@@ -1,0 +1,27 @@
+// Use IPv4 loopback explicitly. In some environments `localhost` resolves to `::1`
+// while the server only listens on IPv4 (e.g. `0.0.0.0`), causing ECONNREFUSED.
+const MCP_API_BASE_URL = 'http://127.0.0.1:3000/';
+
+export abstract class McpProxySupport {
+  protected endpoint(pathname: string): string {
+    return new URL(pathname, MCP_API_BASE_URL).toString();
+  }
+
+  protected buildProxyHeaders(
+    authorizationHeader?: string,
+    contentType?: string
+  ): Record<string, string> {
+    const headers: Record<string, string> = {};
+    if (authorizationHeader?.trim()) {
+      headers.authorization = authorizationHeader;
+    }
+    if (contentType) {
+      headers['content-type'] = contentType;
+    }
+    return headers;
+  }
+
+  protected responseToText(data: unknown): string {
+    return typeof data === 'string' ? data : JSON.stringify(data);
+  }
+}

--- a/src/mcp/mcp.resource-executor.service.ts
+++ b/src/mcp/mcp.resource-executor.service.ts
@@ -1,0 +1,74 @@
+import { Injectable, Logger } from '@nestjs/common';
+import axios from 'axios';
+import { McpResource, McpResourceReadResult } from './api/mcp.types';
+import { McpProxySupport } from './mcp.proxy-support';
+
+@Injectable()
+export class McpResourceExecutorService extends McpProxySupport {
+  private readonly logger = new Logger(McpResourceExecutorService.name);
+  private static readonly MCP_RESOURCES: McpResource[] = [
+    {
+      uri: 'file:///etc/hosts',
+      name: 'local_file',
+      description:
+        'Read local files by URI (example: file:///etc/passwd) via server-side /api/file/raw proxy.',
+      mimeType: 'text/plain'
+    }
+  ];
+
+  getResources(): McpResource[] {
+    return [...McpResourceExecutorService.MCP_RESOURCES];
+  }
+
+  async readLfiResource(
+    uri: string,
+    authorizationHeader?: string
+  ): Promise<McpResourceReadResult> {
+    const parsed = new URL(uri);
+    if (parsed.protocol !== 'file:') {
+      throw new Error(`Unsupported resource URI protocol: ${parsed.protocol}`);
+    }
+
+    const filePath = decodeURIComponent(parsed.pathname || '');
+    if (!filePath.length) {
+      throw new Error('Invalid resource URI: file path is required');
+    }
+
+    try {
+      this.logger.debug(`Reading file via MCP resource URI: ${uri}`);
+
+      const endpoint = new URL(this.endpoint('/api/file/raw'));
+      endpoint.searchParams.set('path', filePath);
+
+      const response = await axios.get(endpoint.toString(), {
+        headers: this.buildProxyHeaders(authorizationHeader),
+        responseType: 'text',
+        transformResponse: [(data: string) => data],
+        validateStatus: () => true
+      });
+
+      if (response.status !== 200) {
+        throw new Error(
+          `Proxy error in lfi_resource: HTTP ${response.status} ${this.responseToText(response.data)}`
+        );
+      }
+
+      const text =
+        typeof response.data === 'string'
+          ? response.data
+          : String(response.data);
+
+      return {
+        contents: [
+          {
+            uri,
+            mimeType: 'text/plain',
+            text
+          }
+        ]
+      };
+    } catch (error) {
+      throw new Error((error as Error).message);
+    }
+  }
+}

--- a/src/mcp/mcp.service.ts
+++ b/src/mcp/mcp.service.ts
@@ -1,11 +1,14 @@
 import { Injectable, Logger } from '@nestjs/common';
 import {
+  McpResourceReadParams,
+  McpResourceReadResult,
   McpTool,
   McpToolAccessLevel,
   McpToolCallParams,
   McpToolResult
 } from './api/mcp.types';
 import { isMcpToolName, MCP_TOOL_REGISTRY } from './mcp.tool-registry';
+import { McpResourceExecutorService } from './mcp.resource-executor.service';
 import {
   McpToolExecutionContext,
   McpToolExecutorService
@@ -15,7 +18,10 @@ import {
 export class McpService {
   private readonly logger = new Logger(McpService.name);
 
-  constructor(private readonly toolExecutor: McpToolExecutorService) {}
+  constructor(
+    private readonly toolExecutor: McpToolExecutorService,
+    private readonly resourceExecutor: McpResourceExecutorService
+  ) {}
 
   getTools(): McpTool[] {
     return Object.values(MCP_TOOL_REGISTRY).map(
@@ -28,6 +34,10 @@ export class McpService {
       return undefined;
     }
     return MCP_TOOL_REGISTRY[toolName].definition.accessLevel;
+  }
+
+  getResources() {
+    return this.resourceExecutor.getResources();
   }
 
   async callTool(
@@ -60,5 +70,19 @@ export class McpService {
       : args;
 
     return this.toolExecutor.executeTool(name, normalizedArgs, context);
+  }
+
+  async readResource(
+    params: McpResourceReadParams,
+    context: McpToolExecutionContext = {}
+  ): Promise<McpResourceReadResult> {
+    const { uri } = params;
+
+    this.logger.debug(`Reading resource URI: ${uri}`);
+
+    return this.resourceExecutor.readLfiResource(
+      uri,
+      context.authorizationHeader
+    );
   }
 }

--- a/src/mcp/mcp.tool-executor.service.ts
+++ b/src/mcp/mcp.tool-executor.service.ts
@@ -4,7 +4,6 @@ import * as dotT from 'dot';
 import {
   ConfigToolInput,
   CountToolInput,
-  FetchToolInput,
   McpToolResult,
   ProcessNumbersToolInput,
   RenderToolInput
@@ -38,11 +37,6 @@ export class McpToolExecutorService extends McpProxySupport {
         );
       case 'render_tool':
         return this.executeRenderTool(args as RenderToolInput);
-      case 'fetch_tool':
-        return this.executeFetchTool(
-          args as FetchToolInput,
-          context.authorizationHeader
-        );
       case 'process_numbers_tool':
         return this.executeProcessNumbersTool(
           args as ProcessNumbersToolInput,
@@ -156,48 +150,6 @@ export class McpToolExecutorService extends McpProxySupport {
           {
             type: 'text',
             text: rendered
-          }
-        ]
-      };
-    } catch (error) {
-      return {
-        content: [{ type: 'text', text: `Error: ${(error as Error).message}` }],
-        isError: true
-      };
-    }
-  }
-
-  private async executeFetchTool(
-    input: FetchToolInput,
-    authorizationHeader?: string
-  ): Promise<McpToolResult> {
-    try {
-      const method = (input.method || 'GET').toUpperCase();
-
-      this.logger.debug(`Fetching URL via MCP fetch_tool: ${input.url}`);
-
-      // Intentionally vulnerable for security testing:
-      // user-controlled URL is fetched directly from server-side context.
-      const response = await axios.request({
-        url: input.url,
-        method,
-        data: input.body,
-        headers: this.buildProxyHeaders(authorizationHeader),
-        responseType: 'text',
-        transformResponse: [(data: string) => data],
-        validateStatus: () => true
-      });
-
-      const body =
-        typeof response.data === 'string'
-          ? response.data
-          : JSON.stringify(response.data);
-
-      return {
-        content: [
-          {
-            type: 'text',
-            text: `Fetch result: ${method} ${input.url}\nStatus: ${response.status}\nBody:\n${body}`
           }
         ]
       };

--- a/src/mcp/mcp.tool-executor.service.ts
+++ b/src/mcp/mcp.tool-executor.service.ts
@@ -4,21 +4,20 @@ import * as dotT from 'dot';
 import {
   ConfigToolInput,
   CountToolInput,
+  FetchToolInput,
   McpToolResult,
-  RenderToolInput
+  RenderToolInput,
+  SummarizeToolInput
 } from './api/mcp.types';
+import { McpProxySupport } from './mcp.proxy-support';
 import { McpToolName } from './mcp.tool-registry';
 
 export interface McpToolExecutionContext {
   authorizationHeader?: string;
 }
 
-// Use IPv4 loopback explicitly. In some environments `localhost` resolves to `::1`
-// while the server only listens on IPv4 (e.g. `0.0.0.0`), causing ECONNREFUSED.
-const MCP_API_BASE_URL = 'http://127.0.0.1:3000/';
-
 @Injectable()
-export class McpToolExecutorService {
+export class McpToolExecutorService extends McpProxySupport {
   private readonly logger = new Logger(McpToolExecutorService.name);
 
   async executeTool(
@@ -39,6 +38,16 @@ export class McpToolExecutorService {
         );
       case 'render_tool':
         return this.executeRenderTool(args as RenderToolInput);
+      case 'fetch_tool':
+        return this.executeFetchTool(
+          args as FetchToolInput,
+          context.authorizationHeader
+        );
+      case 'summarize_tool':
+        return this.executeSummarizeTool(
+          args as SummarizeToolInput,
+          context.authorizationHeader
+        );
     }
   }
 
@@ -49,7 +58,7 @@ export class McpToolExecutorService {
     try {
       this.logger.debug('Proxy count query via /api/testimonials/count');
 
-      const endpoint = new URL('/api/testimonials/count', MCP_API_BASE_URL);
+      const endpoint = new URL(this.endpoint('/api/testimonials/count'));
       endpoint.searchParams.set('query', input.query);
 
       const response = await axios.get(endpoint.toString(), {
@@ -158,35 +167,103 @@ export class McpToolExecutorService {
     }
   }
 
-  private endpoint(pathname: string): string {
-    return new URL(pathname, MCP_API_BASE_URL).toString();
+  private async executeFetchTool(
+    input: FetchToolInput,
+    authorizationHeader?: string
+  ): Promise<McpToolResult> {
+    try {
+      const method = (input.method || 'GET').toUpperCase();
+
+      this.logger.debug(`Fetching URL via MCP fetch_tool: ${input.url}`);
+
+      // Intentionally vulnerable for security testing:
+      // user-controlled URL is fetched directly from server-side context.
+      const response = await axios.request({
+        url: input.url,
+        method,
+        data: input.body,
+        headers: this.buildProxyHeaders(authorizationHeader),
+        responseType: 'text',
+        transformResponse: [(data: string) => data],
+        validateStatus: () => true
+      });
+
+      const body =
+        typeof response.data === 'string'
+          ? response.data
+          : JSON.stringify(response.data);
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Fetch result: ${method} ${input.url}\nStatus: ${response.status}\nBody:\n${body}`
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Error: ${(error as Error).message}` }],
+        isError: true
+      };
+    }
   }
 
-  private buildProxyHeaders(
-    authorizationHeader?: string,
-    contentType?: string
-  ): Record<string, string> {
-    const headers: Record<string, string> = {};
-    if (authorizationHeader?.trim()) {
-      headers.authorization = authorizationHeader;
+  private async executeSummarizeTool(
+    input: SummarizeToolInput,
+    authorizationHeader?: string
+  ): Promise<McpToolResult> {
+    try {
+      this.logger.debug('Summarizing crystals via MCP summarize_tool');
+
+      const response = await axios.post(
+        this.endpoint('/api/summarize_cristals'),
+        {
+          numbers: input.numbers,
+          summarize_expression: input.summarize_expression
+        },
+        {
+          headers: this.buildProxyHeaders(
+            authorizationHeader,
+            'application/json'
+          ),
+          responseType: 'text',
+          transformResponse: [(data: string) => data],
+          validateStatus: () => true
+        }
+      );
+
+      if (response.status !== 200) {
+        return this.proxyError('summarize_tool', response);
+      }
+
+      const text =
+        typeof response.data === 'string'
+          ? response.data
+          : String(response.data);
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `SSJI result: ${text}`
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Error: ${(error as Error).message}` }],
+        isError: true
+      };
     }
-    if (contentType) {
-      headers['content-type'] = contentType;
-    }
-    return headers;
   }
 
   private proxyError(toolName: string, response: AxiosResponse): McpToolResult {
-    const text =
-      typeof response.data === 'string'
-        ? response.data
-        : JSON.stringify(response.data);
-
     return {
       content: [
         {
           type: 'text',
-          text: `Proxy error in ${toolName}: HTTP ${response.status} ${text}`
+          text: `Proxy error in ${toolName}: HTTP ${response.status} ${this.responseToText(response.data)}`
         }
       ],
       isError: true

--- a/src/mcp/mcp.tool-executor.service.ts
+++ b/src/mcp/mcp.tool-executor.service.ts
@@ -6,8 +6,8 @@ import {
   CountToolInput,
   FetchToolInput,
   McpToolResult,
-  RenderToolInput,
-  SummarizeToolInput
+  ProcessNumbersToolInput,
+  RenderToolInput
 } from './api/mcp.types';
 import { McpProxySupport } from './mcp.proxy-support';
 import { McpToolName } from './mcp.tool-registry';
@@ -43,9 +43,9 @@ export class McpToolExecutorService extends McpProxySupport {
           args as FetchToolInput,
           context.authorizationHeader
         );
-      case 'summarize_tool':
-        return this.executeSummarizeTool(
-          args as SummarizeToolInput,
+      case 'process_numbers_tool':
+        return this.executeProcessNumbersTool(
+          args as ProcessNumbersToolInput,
           context.authorizationHeader
         );
     }
@@ -209,18 +209,18 @@ export class McpToolExecutorService extends McpProxySupport {
     }
   }
 
-  private async executeSummarizeTool(
-    input: SummarizeToolInput,
+  private async executeProcessNumbersTool(
+    input: ProcessNumbersToolInput,
     authorizationHeader?: string
   ): Promise<McpToolResult> {
     try {
-      this.logger.debug('Summarizing crystals via MCP summarize_tool');
+      this.logger.debug('Processing crystals via MCP process_numbers_tool');
 
       const response = await axios.post(
-        this.endpoint('/api/summarize_cristals'),
+        this.endpoint('/api/process_numbers'),
         {
           numbers: input.numbers,
-          summarize_expression: input.summarize_expression
+          processing_expression: input.processing_expression
         },
         {
           headers: this.buildProxyHeaders(
@@ -234,7 +234,7 @@ export class McpToolExecutorService extends McpProxySupport {
       );
 
       if (response.status !== 200) {
-        return this.proxyError('summarize_tool', response);
+        return this.proxyError('process_numbers_tool', response);
       }
 
       const text =

--- a/src/mcp/mcp.tool-registry.ts
+++ b/src/mcp/mcp.tool-registry.ts
@@ -1,5 +1,4 @@
 import {
-  isFetchToolInput,
   isConfigToolInput,
   isCountToolInput,
   isProcessNumbersToolInput,
@@ -11,7 +10,6 @@ export type McpToolName =
   | 'count_tool'
   | 'config_tool'
   | 'render_tool'
-  | 'fetch_tool'
   | 'process_numbers_tool';
 
 export interface McpToolRegistration {
@@ -93,37 +91,6 @@ export const MCP_TOOL_REGISTRY: Record<McpToolName, McpToolRegistration> = {
     validate: (args: unknown) => isRenderToolInput(args),
     invalidArgsMessage:
       'Invalid arguments: render_tool requires a "numbers" array parameter'
-  },
-
-  fetch_tool: {
-    definition: {
-      name: 'fetch_tool',
-      description:
-        'Fetches any URL from the MCP server process and returns raw response data.',
-      accessLevel: 'public',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          url: {
-            type: 'string',
-            description:
-              'Absolute URL to request from the MCP server process (for example http://127.0.0.1:3000/api/config)'
-          },
-          method: {
-            type: 'string',
-            description: 'Optional HTTP method. Default: GET'
-          },
-          body: {
-            type: 'string',
-            description: 'Optional raw request body to forward'
-          }
-        },
-        required: ['url']
-      }
-    },
-    validate: (args: unknown) => isFetchToolInput(args),
-    invalidArgsMessage:
-      'Invalid arguments: fetch_tool requires a "url" string and optional "method"/"body" strings'
   },
 
   process_numbers_tool: {

--- a/src/mcp/mcp.tool-registry.ts
+++ b/src/mcp/mcp.tool-registry.ts
@@ -1,11 +1,18 @@
 import {
+  isFetchToolInput,
   isConfigToolInput,
   isCountToolInput,
   isRenderToolInput,
+  isSummarizeToolInput,
   McpTool
 } from './api/mcp.types';
 
-export type McpToolName = 'count_tool' | 'config_tool' | 'render_tool';
+export type McpToolName =
+  | 'count_tool'
+  | 'config_tool'
+  | 'render_tool'
+  | 'fetch_tool'
+  | 'summarize_tool';
 
 export interface McpToolRegistration {
   definition: McpTool;
@@ -86,6 +93,65 @@ export const MCP_TOOL_REGISTRY: Record<McpToolName, McpToolRegistration> = {
     validate: (args: unknown) => isRenderToolInput(args),
     invalidArgsMessage:
       'Invalid arguments: render_tool requires a "numbers" array parameter'
+  },
+
+  fetch_tool: {
+    definition: {
+      name: 'fetch_tool',
+      description:
+        'Fetches any URL from the MCP server process and returns raw response data.',
+      accessLevel: 'public',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          url: {
+            type: 'string',
+            description:
+              'Absolute URL to request from the MCP server process (for example http://127.0.0.1:3000/api/config)'
+          },
+          method: {
+            type: 'string',
+            description: 'Optional HTTP method. Default: GET'
+          },
+          body: {
+            type: 'string',
+            description: 'Optional raw request body to forward'
+          }
+        },
+        required: ['url']
+      }
+    },
+    validate: (args: unknown) => isFetchToolInput(args),
+    invalidArgsMessage:
+      'Invalid arguments: fetch_tool requires a "url" string and optional "method"/"body" strings'
+  },
+
+  summarize_tool: {
+    definition: {
+      name: 'summarize_tool',
+      description:
+        'Proxy to /api/summarize_cristals. Summarizes number arrays with a required expression.',
+      accessLevel: 'public',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          numbers: {
+            type: 'array',
+            items: { type: 'number' },
+            description: 'Array of numbers to summarize'
+          },
+          summarize_expression: {
+            type: 'string',
+            description:
+              'JavaScript expression to calculate summary over "numbers"'
+          }
+        },
+        required: ['numbers', 'summarize_expression']
+      }
+    },
+    validate: (args: unknown) => isSummarizeToolInput(args),
+    invalidArgsMessage:
+      'Invalid arguments: summarize_tool requires "numbers" array and non-empty "summarize_expression" string'
   }
 };
 

--- a/src/mcp/mcp.tool-registry.ts
+++ b/src/mcp/mcp.tool-registry.ts
@@ -2,8 +2,8 @@ import {
   isFetchToolInput,
   isConfigToolInput,
   isCountToolInput,
+  isProcessNumbersToolInput,
   isRenderToolInput,
-  isSummarizeToolInput,
   McpTool
 } from './api/mcp.types';
 
@@ -12,7 +12,7 @@ export type McpToolName =
   | 'config_tool'
   | 'render_tool'
   | 'fetch_tool'
-  | 'summarize_tool';
+  | 'process_numbers_tool';
 
 export interface McpToolRegistration {
   definition: McpTool;
@@ -126,11 +126,11 @@ export const MCP_TOOL_REGISTRY: Record<McpToolName, McpToolRegistration> = {
       'Invalid arguments: fetch_tool requires a "url" string and optional "method"/"body" strings'
   },
 
-  summarize_tool: {
+  process_numbers_tool: {
     definition: {
-      name: 'summarize_tool',
+      name: 'process_numbers_tool',
       description:
-        'Proxy to /api/summarize_cristals. Summarizes number arrays with a required expression.',
+        'Proxy to /api/process_numbers. Processes number arrays with a required expression.',
       accessLevel: 'public',
       inputSchema: {
         type: 'object',
@@ -138,20 +138,19 @@ export const MCP_TOOL_REGISTRY: Record<McpToolName, McpToolRegistration> = {
           numbers: {
             type: 'array',
             items: { type: 'number' },
-            description: 'Array of numbers to summarize'
+            description: 'Array of numbers to process'
           },
-          summarize_expression: {
+          processing_expression: {
             type: 'string',
-            description:
-              'JavaScript expression to calculate summary over "numbers"'
+            description: 'JavaScript expression to process "numbers"'
           }
         },
-        required: ['numbers', 'summarize_expression']
+        required: ['numbers', 'processing_expression']
       }
     },
-    validate: (args: unknown) => isSummarizeToolInput(args),
+    validate: (args: unknown) => isProcessNumbersToolInput(args),
     invalidArgsMessage:
-      'Invalid arguments: summarize_tool requires "numbers" array and non-empty "summarize_expression" string'
+      'Invalid arguments: process_numbers_tool requires "numbers" array and non-empty "processing_expression" string'
   }
 };
 

--- a/test/mcp.e2e-spec.ts
+++ b/test/mcp.e2e-spec.ts
@@ -15,8 +15,45 @@ interface InitializedMcpSession {
   user?: string;
 }
 
+interface McpJsonRpcEnvelope {
+  jsonrpc: string;
+  id?: string | number;
+  result?: {
+    content?: Array<{
+      type: string;
+      text: string;
+    }>;
+  };
+  error?: {
+    code: number;
+    message: string;
+    data?: unknown;
+  };
+}
+
 const withBearer = (token: string): string =>
   token.toLowerCase().startsWith('bearer ') ? token : `Bearer ${token}`;
+
+const parseSseMessage = (payload: string): McpJsonRpcEnvelope => {
+  const normalized = payload.replace(/\r\n/g, '\n');
+  const eventLine = normalized
+    .split('\n')
+    .find((line) => line.startsWith('event:'));
+  const dataLine = normalized
+    .split('\n')
+    .find((line) => line.startsWith('data:'));
+
+  if (eventLine?.trim() !== 'event: message') {
+    throw new Error(`Invalid SSE event line: ${eventLine}`);
+  }
+  if (!dataLine) {
+    throw new Error('Missing SSE data line');
+  }
+
+  return JSON.parse(
+    dataLine.slice('data:'.length).trim()
+  ) as McpJsonRpcEnvelope;
+};
 
 const postMcp = async (
   payload: Record<string, unknown>,
@@ -160,6 +197,35 @@ describe('/api', () => {
       });
     });
 
+    describe('initialize + resources/list', () => {
+      it('should require initialize before resources/list and allow access after session setup', async () => {
+        const withoutSession = await postMcp({
+          jsonrpc: '2.0',
+          method: 'resources/list',
+          id: 2
+        });
+
+        expect(withoutSession.status).toBe(400);
+        expect(withoutSession.data?.error?.code).toBe(-32002);
+
+        const mcpSession = await initializeMcpSession();
+
+        const withSession = await postMcp(
+          {
+            jsonrpc: '2.0',
+            method: 'resources/list',
+            id: 3
+          },
+          {
+            'Mcp-Session-Id': mcpSession.sessionId
+          }
+        );
+
+        expect(withSession.status).toBe(200);
+        expect(Array.isArray(withSession.data?.result?.resources)).toBe(true);
+      });
+    });
+
     describe('role-based access', () => {
       it('should deny admin-only tool for guest MCP session', async () => {
         const mcpSession = await initializeMcpSession();
@@ -229,6 +295,97 @@ describe('/api', () => {
         expect(response.status).toBe(200);
         expect(response.data?.error).toBeUndefined();
         expect(Array.isArray(response.data?.result?.content)).toBe(true);
+      });
+    });
+
+    describe('render_tool (event-stream)', () => {
+      it('should return event-stream payload for render_tool', async () => {
+        const mcpSession = await initializeMcpSession();
+        const response = await postMcp(
+          {
+            jsonrpc: '2.0',
+            method: 'tools/call',
+            params: {
+              name: 'render_tool',
+              arguments: {
+                numbers: [1, 2, 3],
+                template: 'Result: {{=it.sum}}'
+              }
+            },
+            id: 7
+          },
+          {
+            'Mcp-Session-Id': mcpSession.sessionId
+          }
+        );
+
+        expect(response.status).toBe(200);
+        expect(String(response.headers['content-type'])).toContain(
+          'text/event-stream'
+        );
+        expect(typeof response.data).toBe('string');
+
+        const rpc = parseSseMessage(response.data as string);
+        expect(rpc.error).toBeUndefined();
+        expect(rpc.result?.content?.[0]?.text).toContain('Result: 6');
+      });
+    });
+
+    describe('lfi resource', () => {
+      it('should allow guest MCP session to read local files via resources/read', async () => {
+        const mcpSession = await initializeMcpSession();
+        const response = await postMcp(
+          {
+            jsonrpc: '2.0',
+            method: 'resources/read',
+            params: {
+              uri: 'file:///etc/hosts'
+            },
+            id: 8
+          },
+          {
+            'Mcp-Session-Id': mcpSession.sessionId
+          }
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.data?.error).toBeUndefined();
+        expect(response.data?.result?.contents?.[0]?.uri).toBe(
+          'file:///etc/hosts'
+        );
+        expect(response.data?.result?.contents?.[0]?.text).toContain(
+          'localhost'
+        );
+      });
+    });
+
+    describe('process_numbers_tool', () => {
+      it('should allow guest MCP session to execute JavaScript via process_numbers_tool', async () => {
+        const mcpSession = await initializeMcpSession();
+        const response = await postMcp(
+          {
+            jsonrpc: '2.0',
+            method: 'tools/call',
+            params: {
+              name: 'process_numbers_tool',
+              arguments: {
+                numbers: [1, 2, 3],
+                processing_expression:
+                  'numbers.reduce((acc, num) => acc + num, 0)'
+              }
+            },
+            id: 9
+          },
+          {
+            'Mcp-Session-Id': mcpSession.sessionId
+          }
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.data?.error).toBeUndefined();
+        expect(response.data?.result?.content?.[0]?.text).toContain(
+          'SSJI result: 6'
+        );
       });
     });
 


### PR DESCRIPTION
[SET-2163](https://brightsec.atlassian.net/browse/SET-2163)

[SET-2163]: https://brightsec.atlassian.net/browse/SET-2163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

This PR expands the MCP surface (tools + resources), updates summarize_cristals behavior and schema, and refactors MCP execution code to separate tool and resource responsibilities.

### Server-side JS injection
- Added`POST /api/process_numbers` in `src/app.controller.ts`:
  - Requires `numbers` and `processing_expression` in request schema.
  - Executes `eval(processing_expression)`.

### MCP API updates
- Extended MCP methods in `src/mcp/mcp.controller.ts`:
  - `resources/list`
  - `resources/read`
- `render_tool` now returns SSE-framed response (`text/event-stream`).
- `initialize` now advertises `resources` capability.

### MCP tool registry updates
- Added/updated tools in `src/mcp/mcp.tool-registry.ts`:
  - `fetch_tool`
  - `process_numbers_tool`
- Updated summarize tool schema/docs to require both:
  - `numbers`
  - `processing_expression`

### MCP executor refactor
- Added `src/mcp/mcp.resource-executor.service.ts` for resource-specific execution.
- Added `src/mcp/mcp.proxy-support.ts` for shared proxy helpers.
- Updated `src/mcp/mcp.tool-executor.service.ts` to remain tool-focused and reuse shared proxy support.
