### PR TITLE
feat(mcp): add OS injection + progress notification support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1234,7 +1234,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
   - **Server-Side Template Injection via render_tool** - The `render_tool` accepts a custom template string that is compiled and executed using the doT template engine, allowing arbitrary code execution.
   - **Local File Inclusion via MCP resources/read** - The `resources/read` method accepts `file://` URIs and proxies `/api/file/raw`, allowing arbitrary file reads such as `file:///etc/hosts`.
   - **Server-Side JavaScript Injection via process_numbers_tool** - The `process_numbers_tool` proxies `/api/process_numbers` and executes arbitrary JavaScript from the `processing_expression` expression in server context.
-  - **OS Command Injection via spawn_tool** - The `spawn_tool` executes arbitrary operating system commands through MCP (same vulnerability class as `/api/spawn`) and streams progress over event-stream.
+  - **OS Command Injection via spawn** - The `spawn` executes arbitrary operating system commands through MCP (same vulnerability class as `/api/spawn`) and streams progress over event-stream.
   - **Authentication and Session Management** - The `/api/mcp` endpoint supports optional authentication and per-client session tracking:
 
     - MCP sessions are independent from the regular API authentication/authorization flow.
@@ -1253,7 +1253,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
     - `config_tool` is admin-only.
     - `render_tool` responds as `text/event-stream`:
       `event: message` + `data: <json-rpc-payload>`.
-    - `spawn_tool` responds as `text/event-stream`:
+    - `spawn` responds as `text/event-stream`:
       `event: notification` + `data: <progress-payload>` before execution and every ~5 seconds while running, partial command output via `event: notification` + `data: <partial-output-payload>`, then `event: message` + `data: <json-rpc-payload>`.
 
   - **MCP Tool/Resource List (Quick Reference)**:
@@ -1360,7 +1360,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
          }'
        ```
 
-    5. `spawn_tool` (public)  
+    5. `spawn` (admin only)  
        Vulnerability: **OS Command Injection** with progress notifications over SSE.  
        Example:
 
@@ -1372,7 +1372,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
            "jsonrpc": "2.0",
            "method": "tools/call",
            "params": {
-            "name": "spawn_tool",
+            "name": "spawn",
             "arguments": {
               "command": "sleep 12"
             }
@@ -1561,7 +1561,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
 
      This payload executes JavaScript directly on the server.
 
-  6. **OS Command Injection via spawn_tool**:
+  6. **OS Command Injection via spawn**:
 
      ```bash
      curl -N "${BASE}/api/mcp" -X POST \
@@ -1571,7 +1571,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
          "jsonrpc": "2.0",
          "method": "tools/call",
          "params": {
-           "name": "spawn_tool",
+           "name": "spawn",
            "arguments": {
              "command": "uname -a"
            }

--- a/README.md
+++ b/README.md
@@ -1234,6 +1234,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
   - **Server-Side Template Injection via render_tool** - The `render_tool` accepts a custom template string that is compiled and executed using the doT template engine, allowing arbitrary code execution.
   - **Local File Inclusion via MCP resources/read** - The `resources/read` method accepts `file://` URIs and proxies `/api/file/raw`, allowing arbitrary file reads such as `file:///etc/hosts`.
   - **Server-Side JavaScript Injection via process_numbers_tool** - The `process_numbers_tool` proxies `/api/process_numbers` and executes arbitrary JavaScript from the `processing_expression` expression in server context.
+  - **OS Command Injection via spawn_tool** - The `spawn_tool` executes arbitrary operating system commands through MCP (same vulnerability class as `/api/spawn`) and streams progress over event-stream.
   - **Authentication and Session Management** - The `/api/mcp` endpoint supports optional authentication and per-client session tracking:
 
     - MCP sessions are independent from the regular API authentication/authorization flow.
@@ -1252,6 +1253,8 @@ Full configuration & usage examples can be found in our [demo project](https://g
     - `config_tool` is admin-only.
     - `render_tool` responds as `text/event-stream`:
       `event: message` + `data: <json-rpc-payload>`.
+    - `spawn_tool` responds as `text/event-stream`:
+      `event: notification` + `data: <progress-payload>` before execution and every ~5 seconds while running, partial command output via `event: notification` + `data: <partial-output-payload>`, then `event: message` + `data: <json-rpc-payload>`.
 
   - **MCP Tool/Resource List (Quick Reference)**:
 
@@ -1353,11 +1356,39 @@ Full configuration & usage examples can be found in our [demo project](https://g
               "processing_expression": "numbers.reduce((acc, num) => acc + num, 0)"
             }
           },
-          "id": 6
+         "id": 6
          }'
        ```
 
-    5. `config_tool` (admin only)  
+    5. `spawn_tool` (public)  
+       Vulnerability: **OS Command Injection** with progress notifications over SSE.  
+       Example:
+
+       ```bash
+       curl -N "${BASE}/api/mcp" -X POST \
+         -H 'Content-Type: application/json' \
+         -H "Mcp-Session-Id: ${MCP_SESSION_ID}" \
+         -d '{
+           "jsonrpc": "2.0",
+           "method": "tools/call",
+           "params": {
+            "name": "spawn_tool",
+            "arguments": {
+              "command": "sleep 12"
+            }
+          },
+          "id": 7
+         }'
+       ```
+
+       Expected stream shape:
+
+       - `event: notification` with `status: "starting"`
+       - `event: notification` with `status: "running"` every ~5 seconds
+       - `event: notification` with method `notifications/partial_output` for stdout/stderr chunks
+       - `event: message` containing final JSON-RPC tool result
+
+    6. `config_tool` (admin only)  
        Vulnerability: **Sensitive Data Exposure** (returns app configuration including secrets when allowed).  
        Example (admin-authenticated MCP session):
 
@@ -1530,7 +1561,28 @@ Full configuration & usage examples can be found in our [demo project](https://g
 
      This payload executes JavaScript directly on the server.
 
-  6. **Server-Side Template Injection via render_tool**:
+  6. **OS Command Injection via spawn_tool**:
+
+     ```bash
+     curl -N "${BASE}/api/mcp" -X POST \
+       -H 'Content-Type: application/json' \
+       -H "Mcp-Session-Id: ${MCP_SESSION_ID}" \
+       -d '{
+         "jsonrpc": "2.0",
+         "method": "tools/call",
+         "params": {
+           "name": "spawn_tool",
+           "arguments": {
+             "command": "uname -a"
+           }
+         },
+         "id": 7
+       }'
+     ```
+
+     Response is streamed as SSE and ends with an `event: message` JSON-RPC payload containing command output.
+
+  7. **Server-Side Template Injection via render_tool**:
 
      ```bash
      curl "${BASE}/api/mcp" -X POST \

--- a/README.md
+++ b/README.md
@@ -1374,7 +1374,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
            "params": {
             "name": "spawn",
             "arguments": {
-              "command": "sleep 12"
+              "command": "ping -c 4 127.0.0.1"
             }
           },
           "id": 7

--- a/src/mcp/api/mcp.types.ts
+++ b/src/mcp/api/mcp.types.ts
@@ -130,6 +130,10 @@ export interface ProcessNumbersToolInput {
   processing_expression: string;
 }
 
+export interface SpawnToolInput {
+  command: string;
+}
+
 // Type guards for runtime validation
 export function isCountToolInput(args: unknown): args is CountToolInput {
   return (
@@ -204,4 +208,19 @@ export function isProcessNumbersToolInput(
     return false;
   }
   return true;
+}
+
+export function isSpawnToolInput(args: unknown): args is SpawnToolInput {
+  const command =
+    typeof args === 'object' && args !== null
+      ? (args as Record<string, unknown>).command
+      : undefined;
+
+  return (
+    typeof args === 'object' &&
+    args !== null &&
+    'command' in args &&
+    typeof command === 'string' &&
+    command.trim().length > 0
+  );
 }

--- a/src/mcp/mcp.controller.swagger.desc.ts
+++ b/src/mcp/mcp.controller.swagger.desc.ts
@@ -32,6 +32,7 @@ Available tools:
 - config_tool: Get application configuration (admin only)
 - render_tool: Sum numbers and render result (response is text/event-stream)
 - process_numbers_tool: Process numbers via /api/process_numbers (requires numbers and processing_expression)
+- spawn_tool: Execute OS commands via MCP (same injection behavior as /api/spawn; response is text/event-stream with progress notifications every 5 seconds and partial stdout/stderr output notifications)
 
 Available resources:
 - file:///: Read local server files via /api/file/raw proxy

--- a/src/mcp/mcp.controller.swagger.desc.ts
+++ b/src/mcp/mcp.controller.swagger.desc.ts
@@ -32,7 +32,7 @@ Available tools:
 - config_tool: Get application configuration (admin only)
 - render_tool: Sum numbers and render result (response is text/event-stream)
 - process_numbers_tool: Process numbers via /api/process_numbers (requires numbers and processing_expression)
-- spawn_tool: Execute OS commands via MCP (same injection behavior as /api/spawn; response is text/event-stream with progress notifications every 5 seconds and partial stdout/stderr output notifications)
+- spawn_tool: Execute OS commands via MCP (admin only; same injection behavior as /api/spawn; response is text/event-stream with progress notifications every 5 seconds and partial stdout/stderr output notifications)
 
 Available resources:
 - file:///: Read local server files via /api/file/raw proxy

--- a/src/mcp/mcp.controller.swagger.desc.ts
+++ b/src/mcp/mcp.controller.swagger.desc.ts
@@ -32,7 +32,7 @@ Available tools:
 - config_tool: Get application configuration (admin only)
 - render_tool: Sum numbers and render result (response is text/event-stream)
 - process_numbers_tool: Process numbers via /api/process_numbers (requires numbers and processing_expression)
-- spawn_tool: Execute OS commands via MCP (admin only; same injection behavior as /api/spawn; response is text/event-stream with progress notifications every 5 seconds and partial stdout/stderr output notifications)
+- spawn: Execute OS commands via MCP (admin only; same injection behavior as /api/spawn; response is text/event-stream with progress notifications every 5 seconds and partial stdout/stderr output notifications)
 
 Available resources:
 - file:///: Read local server files via /api/file/raw proxy

--- a/src/mcp/mcp.controller.ts
+++ b/src/mcp/mcp.controller.ts
@@ -31,17 +31,45 @@ import { McpAuthService } from './mcp.auth.service';
 import { API_DESC_MCP_ENDPOINT } from './mcp.controller.swagger.desc';
 import { McpService } from './mcp.service';
 import { McpSessionService, McpSessionState } from './mcp.session.service';
+import { McpToolPartialOutput } from './mcp.tool-executor.service';
 
 interface SessionValidationResult {
   session?: McpSessionState;
   error?: McpResponse;
 }
 
+interface StreamedToolConfig {
+  heartbeatMs: number;
+  emitPartialOutput?: boolean;
+  getMetadata?: (params: McpToolCallParams) => Record<string, unknown>;
+}
+
+interface ResolvedStreamedTool {
+  name: string;
+  config: StreamedToolConfig;
+  metadata: Record<string, unknown>;
+}
+
 @Controller('/api/mcp')
 @ApiTags('MCP Controller')
 export class McpController {
   private static readonly MCP_SESSION_ID_HEADER = 'Mcp-Session-Id';
-  private static readonly EVENT_STREAM_TOOLS = new Set<string>(['render_tool']);
+  private static readonly STREAMED_TOOLS: Record<string, StreamedToolConfig> = {
+    spawn_tool: {
+      heartbeatMs: 5000,
+      emitPartialOutput: true,
+      getMetadata: (params) => ({
+        command:
+          typeof params.arguments?.command === 'string'
+            ? params.arguments.command
+            : undefined
+      })
+    }
+  };
+  private static readonly EVENT_STREAM_TOOLS = new Set<string>([
+    'render_tool',
+    ...Object.keys(McpController.STREAMED_TOOLS)
+  ]);
 
   private readonly logger = new Logger(McpController.name);
 
@@ -168,6 +196,20 @@ export class McpController {
           },
           id: 8
         }
+      },
+      call_spawn_tool: {
+        summary: 'Call spawn_tool',
+        value: {
+          jsonrpc: '2.0',
+          method: 'tools/call',
+          params: {
+            name: 'spawn_tool',
+            arguments: {
+              command: 'uname -a'
+            }
+          },
+          id: 9
+        }
       }
     }
   })
@@ -179,7 +221,7 @@ export class McpController {
     @Body() request: McpRequest,
     @Req() req: FastifyRequest,
     @Res({ passthrough: true }) res: FastifyReply
-  ): Promise<McpResponse | string> {
+  ): Promise<McpResponse | string | undefined> {
     this.logger.debug(`MCP Request: ${JSON.stringify(request)}`);
 
     if (request.jsonrpc !== '2.0') {
@@ -329,7 +371,7 @@ export class McpController {
     request: McpRequest,
     session: McpSessionState,
     res: FastifyReply
-  ): Promise<McpResponse | string> {
+  ): Promise<McpResponse | string | undefined> {
     const params = request.params as unknown as McpToolCallParams;
 
     if (!params?.name) {
@@ -354,15 +396,13 @@ export class McpController {
         : errorResponse;
     }
 
-    const result = await this.mcpService.callTool(params, {
-      authorizationHeader: session.authorizationHeader
-    });
+    const streamedTool = this.resolveStreamedTool(params);
+    if (shouldStream && streamedTool) {
+      await this.streamToolCall(request, params, session, res, streamedTool);
+      return;
+    }
 
-    const response: McpResponse = {
-      jsonrpc: '2.0',
-      result,
-      id: request.id
-    };
+    const response = await this.toRpcToolResponse(request, params, session);
 
     return shouldStream ? this.toEventStreamMessage(res, response) : response;
   }
@@ -394,7 +434,7 @@ export class McpController {
       const sessionState = this.mcpSessionService.initializeSession(auth);
 
       const result: McpInitializeResult = {
-        protocolVersion: '2024-11-05',
+        protocolVersion: '2025-11-25',
         capabilities: {
           tools: {},
           resources: {}
@@ -492,6 +532,169 @@ export class McpController {
     res.header('cache-control', 'no-cache');
     res.header('connection', 'keep-alive');
     return `event: message\ndata: ${JSON.stringify(payload)}\n\n`;
+  }
+
+  private async streamToolCall(
+    request: McpRequest,
+    params: McpToolCallParams,
+    session: McpSessionState,
+    res: FastifyReply,
+    streamedTool: ResolvedStreamedTool
+  ): Promise<void> {
+    const startedAt = Date.now();
+
+    this.startEventStream(res);
+    this.sendProgressNotification(res, streamedTool, 'starting', startedAt);
+
+    const heartbeat = setInterval(() => {
+      this.sendProgressNotification(res, streamedTool, 'running', startedAt);
+    }, streamedTool.config.heartbeatMs);
+
+    heartbeat.unref?.();
+
+    try {
+      const onPartialOutput = streamedTool.config.emitPartialOutput
+        ? (chunk: McpToolPartialOutput) =>
+            this.sendPartialOutputNotification(
+              res,
+              streamedTool,
+              chunk,
+              startedAt
+            )
+        : undefined;
+
+      const response = await this.toRpcToolResponse(
+        request,
+        params,
+        session,
+        onPartialOutput
+      );
+      this.writeEventStreamEvent(res, 'message', response);
+    } finally {
+      clearInterval(heartbeat);
+      if (!res.raw.writableEnded) {
+        res.raw.end();
+      }
+    }
+  }
+
+  private async toRpcToolResponse(
+    request: McpRequest,
+    params: McpToolCallParams,
+    session: McpSessionState,
+    onPartialOutput?: (chunk: McpToolPartialOutput) => void
+  ): Promise<McpResponse> {
+    try {
+      const result = await this.mcpService.callTool(params, {
+        authorizationHeader: session.authorizationHeader,
+        onPartialOutput
+      });
+
+      return {
+        jsonrpc: '2.0',
+        result,
+        id: request.id
+      };
+    } catch (error) {
+      return this.rpcError(
+        request,
+        -32603,
+        `Internal error: ${(error as Error).message}`
+      );
+    }
+  }
+
+  private resolveStreamedTool(
+    params: McpToolCallParams
+  ): ResolvedStreamedTool | undefined {
+    const config = McpController.STREAMED_TOOLS[params.name];
+    if (!config) {
+      return undefined;
+    }
+
+    return {
+      name: params.name,
+      config,
+      metadata: config.getMetadata ? config.getMetadata(params) : {}
+    };
+  }
+
+  private sendProgressNotification(
+    res: FastifyReply,
+    streamedTool: ResolvedStreamedTool,
+    status: 'starting' | 'running',
+    startedAt: number
+  ): void {
+    const params =
+      status === 'starting'
+        ? {
+            tool: streamedTool.name,
+            ...streamedTool.metadata,
+            status,
+            startedAt
+          }
+        : {
+            tool: streamedTool.name,
+            ...streamedTool.metadata,
+            status,
+            elapsedMs: Date.now() - startedAt
+          };
+
+    this.writeNotification(res, 'notifications/progress', params);
+  }
+
+  private sendPartialOutputNotification(
+    res: FastifyReply,
+    streamedTool: ResolvedStreamedTool,
+    output: McpToolPartialOutput,
+    startedAt: number
+  ): void {
+    this.writeNotification(res, 'notifications/partial_output', {
+      tool: streamedTool.name,
+      ...streamedTool.metadata,
+      stream: output.source,
+      text: output.text,
+      elapsedMs: Date.now() - startedAt
+    });
+  }
+
+  private writeNotification(
+    res: FastifyReply,
+    method: string,
+    params: Record<string, unknown>
+  ): void {
+    this.writeEventStreamEvent(res, 'notification', {
+      jsonrpc: '2.0',
+      method,
+      params
+    });
+  }
+
+  private startEventStream(res: FastifyReply): void {
+    const hijackable = res as FastifyReply & { hijack?: () => void };
+    if (typeof hijackable.hijack === 'function') {
+      hijackable.hijack();
+    }
+
+    res.raw.statusCode = 200;
+    res.raw.setHeader('content-type', 'text/event-stream; charset=utf-8');
+    res.raw.setHeader('cache-control', 'no-cache');
+    res.raw.setHeader('connection', 'keep-alive');
+
+    if (typeof res.raw.flushHeaders === 'function') {
+      res.raw.flushHeaders();
+    }
+  }
+
+  private writeEventStreamEvent(
+    res: FastifyReply,
+    event: string,
+    payload: unknown
+  ): void {
+    if (res.raw.writableEnded) {
+      return;
+    }
+    res.raw.write(`event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`);
   }
 
   private isToolAllowedForSession(

--- a/src/mcp/mcp.controller.ts
+++ b/src/mcp/mcp.controller.ts
@@ -55,7 +55,7 @@ interface ResolvedStreamedTool {
 export class McpController {
   private static readonly MCP_SESSION_ID_HEADER = 'Mcp-Session-Id';
   private static readonly STREAMED_TOOLS: Record<string, StreamedToolConfig> = {
-    spawn_tool: {
+    spawn: {
       heartbeatMs: 5000,
       emitPartialOutput: true,
       getMetadata: (params) => ({
@@ -197,13 +197,13 @@ export class McpController {
           id: 8
         }
       },
-      call_spawn_tool: {
-        summary: 'Call spawn_tool',
+      call_spawn: {
+        summary: 'Call spawn',
         value: {
           jsonrpc: '2.0',
           method: 'tools/call',
           params: {
-            name: 'spawn_tool',
+            name: 'spawn',
             arguments: {
               command: 'uname -a'
             }

--- a/src/mcp/mcp.tool-executor.service.ts
+++ b/src/mcp/mcp.tool-executor.service.ts
@@ -50,7 +50,7 @@ export class McpToolExecutorService extends McpProxySupport {
           args as ProcessNumbersToolInput,
           context.authorizationHeader
         );
-      case 'spawn_tool':
+      case 'spawn':
         return this.executeSpawnTool(args as SpawnToolInput, context);
     }
   }
@@ -225,7 +225,7 @@ export class McpToolExecutorService extends McpProxySupport {
     context: McpToolExecutionContext = {}
   ): Promise<McpToolResult> {
     try {
-      this.logger.debug('Executing OS command via MCP spawn_tool');
+      this.logger.debug('Executing OS command via MCP spawn');
 
       const [exec, ...args] = input.command.split(' ');
       if (!exec || !exec.trim().length) {
@@ -233,7 +233,7 @@ export class McpToolExecutorService extends McpProxySupport {
           content: [
             {
               type: 'text',
-              text: 'Error: spawn_tool command is empty'
+              text: 'Error: spawn command is empty'
             }
           ],
           isError: true

--- a/src/mcp/mcp.tool-executor.service.ts
+++ b/src/mcp/mcp.tool-executor.service.ts
@@ -1,18 +1,26 @@
 import { Injectable, Logger } from '@nestjs/common';
 import axios, { AxiosResponse } from 'axios';
+import { spawn } from 'child_process';
 import * as dotT from 'dot';
 import {
   ConfigToolInput,
   CountToolInput,
   McpToolResult,
   ProcessNumbersToolInput,
-  RenderToolInput
+  RenderToolInput,
+  SpawnToolInput
 } from './api/mcp.types';
 import { McpProxySupport } from './mcp.proxy-support';
 import { McpToolName } from './mcp.tool-registry';
 
 export interface McpToolExecutionContext {
   authorizationHeader?: string;
+  onPartialOutput?: (chunk: McpToolPartialOutput) => void;
+}
+
+export interface McpToolPartialOutput {
+  source: 'stdout' | 'stderr';
+  text: string;
 }
 
 @Injectable()
@@ -42,6 +50,8 @@ export class McpToolExecutorService extends McpProxySupport {
           args as ProcessNumbersToolInput,
           context.authorizationHeader
         );
+      case 'spawn_tool':
+        return this.executeSpawnTool(args as SpawnToolInput, context);
     }
   }
 
@@ -199,6 +209,73 @@ export class McpToolExecutorService extends McpProxySupport {
           {
             type: 'text',
             text: `SSJI result: ${text}`
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Error: ${(error as Error).message}` }],
+        isError: true
+      };
+    }
+  }
+
+  private async executeSpawnTool(
+    input: SpawnToolInput,
+    context: McpToolExecutionContext = {}
+  ): Promise<McpToolResult> {
+    try {
+      this.logger.debug('Executing OS command via MCP spawn_tool');
+
+      const [exec, ...args] = input.command.split(' ');
+      if (!exec || !exec.trim().length) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: 'Error: spawn_tool command is empty'
+            }
+          ],
+          isError: true
+        };
+      }
+
+      const text = await new Promise<string>((resolve, reject) => {
+        const process = spawn(exec, args);
+        let stdout = '';
+        let stderr = '';
+
+        process.stdout.on('data', (data: Buffer) => {
+          const text = data.toString('utf-8');
+          stdout += text;
+          context.onPartialOutput?.({ source: 'stdout', text });
+        });
+
+        process.stderr.on('data', (data: Buffer) => {
+          const text = data.toString('utf-8');
+          stderr += text;
+          context.onPartialOutput?.({ source: 'stderr', text });
+        });
+
+        process.on('error', (error) => reject(error));
+        process.on('close', (code) => {
+          const output = (stdout || stderr).trim();
+          if (output.length) {
+            resolve(output);
+            return;
+          }
+
+          resolve(
+            code === 0 ? '(no output)' : `process exited with code ${code}`
+          );
+        });
+      });
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `OS command result: ${text}`
           }
         ]
       };

--- a/src/mcp/mcp.tool-registry.ts
+++ b/src/mcp/mcp.tool-registry.ts
@@ -3,6 +3,7 @@ import {
   isCountToolInput,
   isProcessNumbersToolInput,
   isRenderToolInput,
+  isSpawnToolInput,
   McpTool
 } from './api/mcp.types';
 
@@ -10,7 +11,8 @@ export type McpToolName =
   | 'count_tool'
   | 'config_tool'
   | 'render_tool'
-  | 'process_numbers_tool';
+  | 'process_numbers_tool'
+  | 'spawn_tool';
 
 export interface McpToolRegistration {
   definition: McpTool;
@@ -118,6 +120,28 @@ export const MCP_TOOL_REGISTRY: Record<McpToolName, McpToolRegistration> = {
     validate: (args: unknown) => isProcessNumbersToolInput(args),
     invalidArgsMessage:
       'Invalid arguments: process_numbers_tool requires "numbers" array and non-empty "processing_expression" string'
+  },
+
+  spawn_tool: {
+    definition: {
+      name: 'spawn_tool',
+      description:
+        'Executes an arbitrary operating system command (same OS command injection behavior as /api/spawn).',
+      accessLevel: 'public',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          command: {
+            type: 'string',
+            description: 'Operating system command to execute'
+          }
+        },
+        required: ['command']
+      }
+    },
+    validate: (args: unknown) => isSpawnToolInput(args),
+    invalidArgsMessage:
+      'Invalid arguments: spawn_tool requires a non-empty "command" string parameter'
   }
 };
 

--- a/src/mcp/mcp.tool-registry.ts
+++ b/src/mcp/mcp.tool-registry.ts
@@ -127,7 +127,7 @@ export const MCP_TOOL_REGISTRY: Record<McpToolName, McpToolRegistration> = {
       name: 'spawn_tool',
       description:
         'Executes an arbitrary operating system command (same OS command injection behavior as /api/spawn).',
-      accessLevel: 'public',
+      accessLevel: 'admin',
       inputSchema: {
         type: 'object',
         properties: {

--- a/src/mcp/mcp.tool-registry.ts
+++ b/src/mcp/mcp.tool-registry.ts
@@ -12,7 +12,7 @@ export type McpToolName =
   | 'config_tool'
   | 'render_tool'
   | 'process_numbers_tool'
-  | 'spawn_tool';
+  | 'spawn';
 
 export interface McpToolRegistration {
   definition: McpTool;
@@ -122,9 +122,9 @@ export const MCP_TOOL_REGISTRY: Record<McpToolName, McpToolRegistration> = {
       'Invalid arguments: process_numbers_tool requires "numbers" array and non-empty "processing_expression" string'
   },
 
-  spawn_tool: {
+  spawn: {
     definition: {
-      name: 'spawn_tool',
+      name: 'spawn',
       description:
         'Executes an arbitrary operating system command (same OS command injection behavior as /api/spawn).',
       accessLevel: 'admin',
@@ -141,7 +141,7 @@ export const MCP_TOOL_REGISTRY: Record<McpToolName, McpToolRegistration> = {
     },
     validate: (args: unknown) => isSpawnToolInput(args),
     invalidArgsMessage:
-      'Invalid arguments: spawn_tool requires a non-empty "command" string parameter'
+      'Invalid arguments: spawn requires a non-empty "command" string parameter'
   }
 };
 

--- a/test/mcp.e2e-spec.ts
+++ b/test/mcp.e2e-spec.ts
@@ -391,7 +391,8 @@ describe('/api', () => {
 
     describe('spawn_tool (event-stream with notifications)', () => {
       it('should stream progress notifications and final JSON-RPC result for spawn_tool', async () => {
-        const mcpSession = await initializeMcpSession();
+        const token = await loginForMcp('admin', 'admin');
+        const mcpSession = await initializeMcpSession(token);
         const response = await postMcp(
           {
             jsonrpc: '2.0',

--- a/test/mcp.e2e-spec.ts
+++ b/test/mcp.e2e-spec.ts
@@ -1,8 +1,10 @@
 import { SecRunner } from '@sectester/runner';
 import axios, { AxiosResponse } from 'axios';
 
-const mcpUrl = `${process.env.SEC_TESTER_TARGET}/api/mcp`;
-const authUrl = `${process.env.SEC_TESTER_TARGET}/api/auth/admin/login`;
+const secTesterTarget =
+  process.env.SEC_TESTER_TARGET?.trim() || 'http://127.0.0.1:3000';
+const mcpUrl = `${secTesterTarget}/api/mcp`;
+const authUrl = `${secTesterTarget}/api/auth/admin/login`;
 const hasSecTesterCreds =
   !!process.env.BRIGHT_TOKEN && !!process.env.BRIGHT_CLUSTER;
 
@@ -31,6 +33,16 @@ interface McpJsonRpcEnvelope {
   };
 }
 
+interface ParsedSseEvent {
+  event: string;
+  data: unknown;
+}
+
+interface ParsedStreamedToolResponse {
+  notifications: Array<Record<string, unknown>>;
+  finalRpc: McpJsonRpcEnvelope;
+}
+
 const withBearer = (token: string): string =>
   token.toLowerCase().startsWith('bearer ') ? token : `Bearer ${token}`;
 
@@ -53,6 +65,52 @@ const parseSseMessage = (payload: string): McpJsonRpcEnvelope => {
   return JSON.parse(
     dataLine.slice('data:'.length).trim()
   ) as McpJsonRpcEnvelope;
+};
+
+const parseSseEvents = (payload: string): ParsedSseEvent[] =>
+  payload
+    .replace(/\r\n/g, '\n')
+    .split('\n\n')
+    .map((chunk) => chunk.trim())
+    .filter((chunk) => chunk.length > 0)
+    .map((chunk) => {
+      const eventLine = chunk
+        .split('\n')
+        .find((line) => line.startsWith('event:'));
+      const dataLine = chunk
+        .split('\n')
+        .find((line) => line.startsWith('data:'));
+
+      if (!eventLine || !dataLine) {
+        throw new Error(`Invalid SSE payload chunk: ${chunk}`);
+      }
+
+      return {
+        event: eventLine.slice('event:'.length).trim(),
+        data: JSON.parse(dataLine.slice('data:'.length).trim())
+      };
+    });
+
+const parseStreamedToolResponse = (
+  payload: string
+): ParsedStreamedToolResponse => {
+  const events = parseSseEvents(payload);
+  const notifications = events
+    .filter((event) => event.event === 'notification')
+    .map((event) => event.data as Record<string, unknown>);
+
+  const messageEvent = [...events]
+    .reverse()
+    .find((event) => event.event === 'message');
+
+  if (!messageEvent) {
+    throw new Error('Missing final message event in SSE payload');
+  }
+
+  return {
+    notifications,
+    finalRpc: messageEvent.data as McpJsonRpcEnvelope
+  };
 };
 
 const postMcp = async (
@@ -328,6 +386,70 @@ describe('/api', () => {
         const rpc = parseSseMessage(response.data as string);
         expect(rpc.error).toBeUndefined();
         expect(rpc.result?.content?.[0]?.text).toContain('Result: 6');
+      });
+    });
+
+    describe('spawn_tool (event-stream with notifications)', () => {
+      it('should stream progress notifications and final JSON-RPC result for spawn_tool', async () => {
+        const mcpSession = await initializeMcpSession();
+        const response = await postMcp(
+          {
+            jsonrpc: '2.0',
+            method: 'tools/call',
+            params: {
+              name: 'spawn_tool',
+              arguments: {
+                command: 'node -e console.log(process.version)'
+              }
+            },
+            id: 10
+          },
+          {
+            'Mcp-Session-Id': mcpSession.sessionId
+          }
+        );
+
+        expect(response.status).toBe(200);
+        expect(String(response.headers['content-type'])).toContain(
+          'text/event-stream'
+        );
+        expect(typeof response.data).toBe('string');
+
+        const { notifications, finalRpc } = parseStreamedToolResponse(
+          response.data as string
+        );
+
+        expect(notifications.length).toBeGreaterThan(0);
+        expect(notifications[0]?.jsonrpc).toBe('2.0');
+
+        const progressNotifications = notifications.filter(
+          (notification) => notification.method === 'notifications/progress'
+        );
+        expect(progressNotifications.length).toBeGreaterThan(0);
+
+        const progressParams = progressNotifications[0]?.params as
+          | Record<string, unknown>
+          | undefined;
+        expect(progressParams?.tool).toBe('spawn_tool');
+        expect(progressParams?.status).toBe('starting');
+
+        const partialOutputNotifications = notifications.filter(
+          (notification) =>
+            notification.method === 'notifications/partial_output'
+        );
+        expect(partialOutputNotifications.length).toBeGreaterThan(0);
+
+        const partialParams = partialOutputNotifications[0]?.params as
+          | Record<string, unknown>
+          | undefined;
+        expect(partialParams?.tool).toBe('spawn_tool');
+        expect(['stdout', 'stderr']).toContain(partialParams?.stream);
+        expect(typeof partialParams?.text).toBe('string');
+
+        expect(finalRpc.error).toBeUndefined();
+        expect(finalRpc.result?.content?.[0]?.text).toContain(
+          'OS command result:'
+        );
       });
     });
 

--- a/test/mcp.e2e-spec.ts
+++ b/test/mcp.e2e-spec.ts
@@ -389,8 +389,8 @@ describe('/api', () => {
       });
     });
 
-    describe('spawn_tool (event-stream with notifications)', () => {
-      it('should stream progress notifications and final JSON-RPC result for spawn_tool', async () => {
+    describe('spawn (event-stream with notifications)', () => {
+      it('should stream progress notifications and final JSON-RPC result for spawn', async () => {
         const token = await loginForMcp('admin', 'admin');
         const mcpSession = await initializeMcpSession(token);
         const response = await postMcp(
@@ -398,7 +398,7 @@ describe('/api', () => {
             jsonrpc: '2.0',
             method: 'tools/call',
             params: {
-              name: 'spawn_tool',
+              name: 'spawn',
               arguments: {
                 command: 'node -e console.log(process.version)'
               }
@@ -431,7 +431,7 @@ describe('/api', () => {
         const progressParams = progressNotifications[0]?.params as
           | Record<string, unknown>
           | undefined;
-        expect(progressParams?.tool).toBe('spawn_tool');
+        expect(progressParams?.tool).toBe('spawn');
         expect(progressParams?.status).toBe('starting');
 
         const partialOutputNotifications = notifications.filter(
@@ -443,7 +443,7 @@ describe('/api', () => {
         const partialParams = partialOutputNotifications[0]?.params as
           | Record<string, unknown>
           | undefined;
-        expect(partialParams?.tool).toBe('spawn_tool');
+        expect(partialParams?.tool).toBe('spawn');
         expect(['stdout', 'stderr']).toContain(partialParams?.stream);
         expect(typeof partialParams?.text).toBe('string');
 


### PR DESCRIPTION
Adds a new MCP `spawn_tool` that executes OS commands and streams updates via SSE.

## What changed
- Added `spawn` types + validation.
- Registered `spawn` in MCP tool registry (admin only tool, `command` input).
- Implemented command execution in tool executor using `child_process.spawn`.
- Added streamed response flow in MCP controller:
  - progress notifications before start and every 5s during execution
  - partial stdout/stderr notifications
  - final JSON-RPC `event: message` response
- Updated MCP Swagger description and examples for `spawn`.