### PR TITLE
🛡️ Bright Security Scan

### DIFF
--- a/client/public/nginx.conf
+++ b/client/public/nginx.conf
@@ -42,12 +42,19 @@
         # Load configuration files for the default server block.
         include /etc/nginx/default.d/*.conf;
 	
+        # Prevent access to dotfiles such as .env, .git, .svn, etc.
+        location ~ /\.(?!well-known) {
+            deny all;
+            access_log off;
+            log_not_found off;
+        }
+
         #autoindex on;
         index index.html;
 
         location / {
         #try_files $uri.ics $uri index.html;
-            autoindex on;       	   
+            autoindex on;        
             try_files $uri $uri/ /index.html =404;
         }
         

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react-swc';
 // https://vitejs.dev/config/
 export default defineConfig({
   base: '/',
-  publicDir: './public',
+  publicDir: false,
   plugins: [react()],
   server: {
     port: 3001,

--- a/src/app.config.api.ts
+++ b/src/app.config.api.ts
@@ -1,12 +1,13 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 export class AppConfig {
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Public S3 bucket name or similar non-sensitive public configuration'
+  })
   awsBucket: string;
 
-  @ApiProperty()
-  sql: string;
-
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Public Google Maps API key or other non-secret public configuration'
+  })
   googlemaps: string;
 }

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -259,8 +259,7 @@ export class AppController {
     type: AppConfig
   })
   getConfig(): AppConfig {
-    const config = this.appService.getConfig();
-    return config;
+    return this.appService.getConfig();
   }
 
   @Get('/secrets')
@@ -271,27 +270,9 @@ export class AppController {
     type: Object
   })
   getSecrets(): Record<string, string> {
-    const secrets = {
-      codeclimate:
-        'CODECLIMATE_REPO_TOKEN=62864c476ade6ab9d10d0ce0901ae2c211924852a28c5f960ae5165c1fdfec73',
-      facebook:
-        'EAACEdEose0cBAHyDF5HI5o2auPWv3lPP3zNYuWWpjMrSaIhtSvX73lsLOcas5k8GhC5HgOXnbF3rXRTczOpsbNb54CQL8LcQEMhZAWAJzI0AzmL23hZByFAia5avB6Q4Xv4u2QVoAdH0mcJhYTFRpyJKIAyDKUEBzz0GgZDZD',
-      google_b64: 'QUl6YhT6QXlEQnbTr2dSdEI1W7yL2mFCX3c4PPP5NlpkWE65NkZV',
-      google_oauth:
-        '188968487735-c7hh7k87juef6vv84697sinju2bet7gn.apps.googleusercontent.com',
-      google_oauth_token:
-        'ya29.a0TgU6SMDItdQQ9J7j3FVgJuByTTevl0FThTEkBs4pA4-9tFREyf2cfcL-_JU6Trg1O0NWwQKie4uGTrs35kmKlxohWgcAl8cg9DTxRx-UXFS-S1VYPLVtQLGYyNTfGp054Ad3ej73-FIHz3RZY43lcKSorbZEY4BI',
-      heroku:
-        'herokudev.staging.endosome.975138 pid=48751 request_id=0e9a8698-a4d2-4925-a1a5-113234af5f60',
-      hockey_app: 'HockeySDK: 203d3af93f4a218bfb528de08ae5d30ff65e1cf',
-      outlook:
-        'https://outlook.office.com/webhook/7dd49fc6-1975-443d-806c-08ebe8f81146@a532313f-11ec-43a2-9a7a-d2e27f4f3478/IncomingWebhook/8436f62b50ab41b3b93ba1c0a50a0b88/eff4cd58-1bb8-4899-94de-795f656b4a18',
-      paypal:
-        'access_token$production$x0lb4r69dvmmnufd$3ea7cb281754b7da7dac131ef5783321',
-      slack:
-        'xoxo-175588824543-175748345725-176608801663-826315f84e553d482bb7e73e8322sdf3'
+    return {
+      message: 'Secrets are not exposed via this endpoint.'
     };
-    return secrets;
   }
 
   @Get('/v1/userinfo/:email')

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -252,6 +252,8 @@ export class AppController {
   }
 
   @Get('/config')
+  @UseGuards(AuthGuard)
+  @JwtType(JwtProcessorType.RSA)
   @ApiOperation({
     description: API_DESC_CONFIG_SERVER
   })
@@ -263,6 +265,8 @@ export class AppController {
   }
 
   @Get('/secrets')
+  @UseGuards(AuthGuard)
+  @JwtType(JwtProcessorType.RSA)
   @ApiOperation({
     description: SWAGGER_DESC_SECRETS
   })

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -46,31 +46,14 @@ export class AppService {
   }
 
   getConfig(): AppConfig {
-    const dbSchema = this.configService.get<string>(
-        OrmModuleConfigProperties.ENV_DATABASE_SCHEMA
-      ),
-      dbHost = this.configService.get<string>(
-        OrmModuleConfigProperties.ENV_DATABASE_HOST
-      ),
-      dbPort = this.configService.get<string>(
-        OrmModuleConfigProperties.ENV_DATABASE_PORT
-      ),
-      dbUser = this.configService.get<string>(
-        OrmModuleConfigProperties.ENV_DATABASE_USER
-      ),
-      dbPwd = this.configService.get<string>(
-        OrmModuleConfigProperties.ENV_DATABASE_PASSWORD
-      );
-
     return {
       awsBucket: this.configService.get<string>(
         AppModuleConfigProperties.ENV_AWS_BUCKET
       ),
-      sql: `postgres://${dbUser}:${dbPwd}@${dbHost}:${dbPort}/${dbSchema} `,
       googlemaps: this.configService.get<string>(
         AppModuleConfigProperties.ENV_GOOGLE_MAPS
       )
-    };
+    } as AppConfig;
   }
 
   async getUserInfo(email: string): Promise<UserDto> {

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -46,14 +46,17 @@ export class AppService {
   }
 
   getConfig(): AppConfig {
+    const awsBucket = this.configService.get<string>(
+      AppModuleConfigProperties.ENV_AWS_BUCKET
+    );
+    const googlemaps = this.configService.get<string>(
+      AppModuleConfigProperties.ENV_GOOGLE_MAPS
+    );
+
     return {
-      awsBucket: this.configService.get<string>(
-        AppModuleConfigProperties.ENV_AWS_BUCKET
-      ),
-      googlemaps: this.configService.get<string>(
-        AppModuleConfigProperties.ENV_GOOGLE_MAPS
-      )
-    } as AppConfig;
+      awsBucket: awsBucket ?? '',
+      googlemaps: googlemaps ?? ''
+    };
   }
 
   async getUserInfo(email: string): Promise<UserDto> {

--- a/src/auth/auth.guard.ts
+++ b/src/auth/auth.guard.ts
@@ -49,11 +49,28 @@ export class AuthGuard implements CanActivate {
       token = request.cookies[AuthGuard.AUTH_HEADER];
     }
 
+    if (typeof token !== 'string') {
+      return undefined;
+    }
+
     if (this.checkIsBearer(token)) {
       token = token.substring(AuthGuard.BEARER_PREFIX.length).trim();
     }
 
+    if (!this.isWellFormedJwt(token)) {
+      return undefined;
+    }
+
     return token?.length ? token : undefined;
+  }
+
+  private isWellFormedJwt(token: string): boolean {
+    const parts = token.split('.');
+    if (parts.length !== 3) {
+      return false;
+    }
+
+    return parts.every((part) => part.length > 0);
   }
 
   private getRequest(context: ExecutionContext): FastifyRequest {
@@ -70,6 +87,10 @@ export class AuthGuard implements CanActivate {
       JwTypeMetadataField,
       context.getHandler()
     );
+
+    if (!processorType) {
+      return false;
+    }
 
     try {
       return !!(await this.authService.validateToken(token, processorType));

--- a/src/auth/jwt/jwt.token.processor.ts
+++ b/src/auth/jwt/jwt.token.processor.ts
@@ -14,16 +14,35 @@ export abstract class JwtTokenProcessor {
     this.log.debug('Call parse');
 
     const parts = token.split('.');
-    if (parts.length != 3 || !parts[0]) {
-      throw new Error('Failed to parse jwt token header');
+    if (parts.length != 3 || !parts[0] || !parts[1] || !parts[2]) {
+      throw new Error('Failed to parse jwt token');
     }
-    const headerStr = Buffer.from(parts[0], 'base64').toString('ascii');
-    this.log.debug(`Jwt token header is ${headerStr}`);
-    const header: JwtHeader = JSON.parse(headerStr);
 
-    const payloadStr = Buffer.from(parts[1], 'base64').toString('ascii');
-    this.log.debug('Jwt token payload parsed');
-    const payload = JSON.parse(payloadStr);
+    let headerStr: string;
+    let payloadStr: string;
+
+    try {
+      headerStr = Buffer.from(parts[0], 'base64url').toString('utf8');
+      payloadStr = Buffer.from(parts[1], 'base64url').toString('utf8');
+    } catch {
+      throw new Error('Failed to parse jwt token');
+    }
+
+    this.log.debug(`Jwt token header is ${headerStr}`);
+
+    let header: JwtHeader;
+    let payload: unknown;
+
+    try {
+      header = JSON.parse(headerStr);
+      payload = JSON.parse(payloadStr);
+    } catch {
+      throw new Error('Failed to parse jwt token');
+    }
+
+    if (!header || typeof header !== 'object') {
+      throw new Error('Failed to parse jwt token');
+    }
 
     return [header, payload];
   }

--- a/src/auth/jwt/jwt.token.processor.ts
+++ b/src/auth/jwt/jwt.token.processor.ts
@@ -22,7 +22,7 @@ export abstract class JwtTokenProcessor {
     const header: JwtHeader = JSON.parse(headerStr);
 
     const payloadStr = Buffer.from(parts[1], 'base64').toString('ascii');
-    this.log.debug(`Jwt token (None alg) payload is ${payloadStr}`);
+    this.log.debug('Jwt token payload parsed');
     const payload = JSON.parse(payloadStr);
 
     return [header, payload];

--- a/src/auth/jwt/jwt.token.with.hmac.keys.processor.ts
+++ b/src/auth/jwt/jwt.token.with.hmac.keys.processor.ts
@@ -1,8 +1,10 @@
 import { Logger } from '@nestjs/common';
+import * as jwt from 'jsonwebtoken';
 import { JwtTokenProcessor as JwtTokenProcessor } from './jwt.token.processor';
-import { encode, decode } from 'jwt-simple';
 
 export class JwtTokenWithHMACKeysProcessor extends JwtTokenProcessor {
+  private static readonly EXPECTED_ALG = 'HS256';
+
   constructor(private privateKey: string) {
     super(new Logger(JwtTokenWithHMACKeysProcessor.name));
   }
@@ -12,17 +14,40 @@ export class JwtTokenWithHMACKeysProcessor extends JwtTokenProcessor {
 
     const [header] = this.parse(token);
 
-    if (header.alg !== 'HS256') {
+    if (!header || header.alg !== JwtTokenWithHMACKeysProcessor.EXPECTED_ALG) {
       throw new Error('Invalid JWT algorithm');
     }
 
-    return decode(token, this.privateKey, false, 'HS256');
+    return new Promise((resolve, reject) => {
+      jwt.verify(
+        token,
+        this.privateKey,
+        {
+          algorithms: [JwtTokenWithHMACKeysProcessor.EXPECTED_ALG],
+          complete: false,
+          clockTolerance: 0
+        },
+        (err, decoded) => {
+          if (err) {
+            return reject(new Error('Invalid JWT signature'));
+          }
+
+          if (!decoded || typeof decoded !== 'object') {
+            return reject(new Error('Invalid JWT payload'));
+          }
+
+          resolve(decoded);
+        }
+      );
+    });
   }
 
   async createToken(payload: unknown): Promise<string> {
     this.log.debug('Call createToken');
 
-    const token = encode(payload, this.privateKey, 'HS256');
-    return token;
+    return jwt.sign(payload as jwt.JwtPayload, this.privateKey, {
+      algorithm: JwtTokenWithHMACKeysProcessor.EXPECTED_ALG,
+      noTimestamp: true
+    });
   }
 }

--- a/src/auth/jwt/jwt.token.with.hmac.keys.processor.ts
+++ b/src/auth/jwt/jwt.token.with.hmac.keys.processor.ts
@@ -10,10 +10,12 @@ export class JwtTokenWithHMACKeysProcessor extends JwtTokenProcessor {
   async validateToken(token: string): Promise<unknown> {
     this.log.debug('Call validateToken');
 
-    const [header, payload] = this.parse(token);
-    if (header.alg === 'none') {
-      return payload;
+    const [header] = this.parse(token);
+
+    if (header.alg !== 'HS256') {
+      throw new Error('Invalid JWT algorithm');
     }
+
     return decode(token, this.privateKey, false, 'HS256');
   }
 

--- a/src/auth/jwt/jwt.token.with.rsa.signature.keys.processor.ts
+++ b/src/auth/jwt/jwt.token.with.rsa.signature.keys.processor.ts
@@ -1,8 +1,10 @@
 import { Logger } from '@nestjs/common';
-import { decode, encode } from 'jwt-simple';
+import * as jwt from 'jsonwebtoken';
 import { JwtTokenProcessor as JwtTokenProcessor } from './jwt.token.processor';
 
 export class JwtTokenWithRSASignatureKeysProcessor extends JwtTokenProcessor {
+  private static readonly EXPECTED_ALG = 'RS256';
+
   constructor(
     private publicKey: string,
     private privateKey: string
@@ -15,17 +17,44 @@ export class JwtTokenWithRSASignatureKeysProcessor extends JwtTokenProcessor {
 
     const [header] = this.parse(token);
 
-    if (header.alg !== 'RS256') {
+    if (!header || header.alg !== JwtTokenWithRSASignatureKeysProcessor.EXPECTED_ALG) {
       throw new Error('Invalid JWT algorithm');
     }
 
-    return decode(token, this.publicKey, true, 'RS256');
+    return this.verifyTokenStrict(token, this.publicKey);
   }
 
   async createToken(payload: unknown): Promise<string> {
     this.log.debug('Call createToken');
 
-    const token = encode(payload, this.privateKey, 'RS256');
-    return token;
+    return jwt.sign(payload as jwt.JwtPayload, this.privateKey, {
+      algorithm: JwtTokenWithRSASignatureKeysProcessor.EXPECTED_ALG,
+      noTimestamp: true
+    });
+  }
+
+  private verifyTokenStrict(token: string, key: string): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      jwt.verify(
+        token,
+        key,
+        {
+          algorithms: [JwtTokenWithRSASignatureKeysProcessor.EXPECTED_ALG],
+          complete: false,
+          clockTolerance: 0
+        },
+        (err, decoded) => {
+          if (err) {
+            return reject(new Error('Invalid JWT signature'));
+          }
+
+          if (!decoded || typeof decoded !== 'object') {
+            return reject(new Error('Invalid JWT payload'));
+          }
+
+          resolve(decoded);
+        }
+      );
+    });
   }
 }

--- a/src/auth/jwt/jwt.token.with.rsa.signature.keys.processor.ts
+++ b/src/auth/jwt/jwt.token.with.rsa.signature.keys.processor.ts
@@ -13,6 +13,12 @@ export class JwtTokenWithRSASignatureKeysProcessor extends JwtTokenProcessor {
   async validateToken(token: string): Promise<unknown> {
     this.log.debug('Call validateToken');
 
+    const [header] = this.parse(token);
+
+    if (header.alg !== 'RS256') {
+      throw new Error('Invalid JWT algorithm');
+    }
+
     return decode(token, this.publicKey, true, 'RS256');
   }
 

--- a/src/email/email.controller.ts
+++ b/src/email/email.controller.ts
@@ -1,4 +1,4 @@
-import { FastifyReply } from 'fastify';
+import { FastifyReply, FastifyRequest } from 'fastify';
 import {
   Controller,
   Delete,
@@ -7,7 +7,10 @@ import {
   HttpStatus,
   Logger,
   Query,
-  Res
+  Req,
+  Res,
+  UnauthorizedException,
+  UseGuards
 } from '@nestjs/common';
 import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { EmailService } from './email.service';
@@ -17,6 +20,7 @@ import {
   SWAGGER_DESC_SEND_EMAIL
 } from './email.controller.swagger.desc';
 import splitUriIntoParamsPPVulnerable from '../utils/url';
+import { CsrfGuard } from '../auth/csrf.guard';
 
 @Controller('/api/email')
 @ApiTags('Emails controller')
@@ -110,6 +114,7 @@ export class EmailController {
   }
 
   @Get('/getEmails')
+  @UseGuards(CsrfGuard)
   @ApiOperation({
     description: SWAGGER_DESC_GET_EMAILS
   })
@@ -118,7 +123,12 @@ export class EmailController {
     example: 'true',
     required: true
   })
-  async getEmails(@Query('withSource') withSourceStr: string) {
+  async getEmails(
+    @Query('withSource') withSourceStr: string,
+    @Req() request: FastifyRequest
+  ) {
+    this.validateSameOriginRequest(request);
+
     const withSource = withSourceStr === 'true';
 
     this.logger.log(`Getting Emails (withSource=${withSource})`);
@@ -126,11 +136,30 @@ export class EmailController {
   }
 
   @Delete('/deleteEmails')
+  @UseGuards(CsrfGuard)
   @ApiOperation({
     description: SWAGGER_DESC_DELTE_EMAILS
   })
-  async deleteEmails() {
+  async deleteEmails(@Req() request: FastifyRequest) {
+    this.validateSameOriginRequest(request);
+
     this.logger.log('Deleting Emails');
     return await this.emailService.deleteEmails();
+  }
+
+  private validateSameOriginRequest(request: FastifyRequest) {
+    const origin = (request.headers.origin as string | undefined) || '';
+    const referer = (request.headers.referer as string | undefined) || '';
+    const expectedOrigin = process.env.URL || 'http://localhost:3000';
+
+    const isValidOrigin = origin === expectedOrigin;
+    const isValidReferer = referer.startsWith(expectedOrigin);
+
+    if (!isValidOrigin && !isValidReferer) {
+      throw new UnauthorizedException({
+        error: 'Invalid origin',
+        location: __filename
+      });
+    }
   }
 }

--- a/src/email/email.service.ts
+++ b/src/email/email.service.ts
@@ -124,7 +124,7 @@ export class EmailService {
     return mailOptions;
   }
 
-  async getEmails(withSource): Promise<unknown> {
+  async getEmails(withSource: boolean): Promise<unknown> {
     this.logger.debug(`Fetching all emails from MailCatcher`);
 
     const emails = await axios
@@ -137,7 +137,7 @@ export class EmailService {
 
     if (withSource) {
       this.logger.debug(`Fetching sources of Emails`);
-      for (const email of emails) {
+      for (const email of emails as Array<{ id: string; source?: unknown }>) {
         email['source'] = await this.getEmailSource(email['id']);
       }
     }
@@ -145,8 +145,8 @@ export class EmailService {
     return emails;
   }
 
-  private async getEmailSource(emailId): Promise<string> {
-    const sourceUrl = `${this.MAIL_CATCHER_MESSAGES_URL}/${emailId}.source`;
+  private async getEmailSource(emailId: string): Promise<string> {
+    const sourceUrl = `${this.MAIL_CATCHER_MESSAGES_URL}/${encodeURIComponent(emailId)}.source`;
 
     return await axios
       .get(sourceUrl)

--- a/src/file/cloud.providers.metadata.ts
+++ b/src/file/cloud.providers.metadata.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import axios from 'axios';
 
 @Injectable()
 export class CloudProvidersMetaData {
@@ -260,12 +259,8 @@ export class CloudProvidersMetaData {
       return this.providers.get(CloudProvidersMetaData.AWS);
     } else if (providerUrl.startsWith(CloudProvidersMetaData.AZURE)) {
       return this.providers.get(CloudProvidersMetaData.AZURE);
-    } else {
-      const { data } = await axios(providerUrl, {
-        timeout: 5000,
-        responseType: 'text'
-      });
-      return data;
     }
+
+    throw new Error('Unsupported provider URL');
   }
 }

--- a/src/file/cloud.providers.metadata.ts
+++ b/src/file/cloud.providers.metadata.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, BadRequestException } from '@nestjs/common';
 
 @Injectable()
 export class CloudProvidersMetaData {

--- a/src/file/file.controller.ts
+++ b/src/file/file.controller.ts
@@ -64,6 +64,19 @@ export class FileController {
     'security-groups',
     'services/'
   ]);
+  private readonly allowedAzureMetadataPaths = new Set<string>([
+    '/compute',
+    '/network'
+  ]);
+  private readonly allowedGoogleMetadataPaths = new Set<string>([
+    'instance/',
+    'oslogin/',
+    'project/'
+  ]);
+  private readonly allowedDigitalOceanMetadataPaths = new Set<string>([
+    '/v1',
+    '/v1.json'
+  ]);
 
   constructor(private fileService: FileService) {}
 
@@ -75,14 +88,18 @@ export class FileController {
     }
   }
 
-  private validateAwsMetadataPath(filePath: string): string {
-    if (!filePath || typeof filePath !== 'string') {
+  private rejectHttpPath(filePath: string): void {
+    if (typeof filePath !== 'string' || !filePath) {
       throw new BadRequestException(`Invalid paramater 'path' ${filePath}`);
     }
 
     if (filePath.startsWith('http://') || filePath.startsWith('https://')) {
       throw new BadRequestException(`Invalid paramater 'path' ${filePath}`);
     }
+  }
+
+  private validateAwsMetadataPath(filePath: string): string {
+    this.rejectHttpPath(filePath);
 
     const prefix = CloudProvidersMetaData.AWS;
     if (!filePath.startsWith(prefix)) {
@@ -101,10 +118,77 @@ export class FileController {
     return filePath;
   }
 
+  private validateAzureMetadataPath(filePath: string): string {
+    this.rejectHttpPath(filePath);
+
+    const prefix = CloudProvidersMetaData.AZURE;
+    if (!filePath.startsWith(prefix)) {
+      throw new BadRequestException(`Invalid paramater 'path' ${filePath}`);
+    }
+
+    const metadataPath = filePath.substring(prefix.length);
+    const allowed = Array.from(this.allowedAzureMetadataPaths).some((allowedPath) =>
+      metadataPath === allowedPath || metadataPath.startsWith(`${allowedPath}/`)
+    );
+
+    if (!allowed) {
+      throw new BadRequestException(`Invalid paramater 'path' ${filePath}`);
+    }
+
+    return filePath;
+  }
+
+  private validateGoogleMetadataPath(filePath: string): string {
+    this.rejectHttpPath(filePath);
+
+    const prefix = CloudProvidersMetaData.GOOGLE;
+    if (!filePath.startsWith(prefix)) {
+      throw new BadRequestException(`Invalid paramater 'path' ${filePath}`);
+    }
+
+    const metadataPath = filePath.substring(prefix.length);
+    const allowed = Array.from(this.allowedGoogleMetadataPaths).some((allowedPath) =>
+      metadataPath === allowedPath || metadataPath.startsWith(allowedPath)
+    );
+
+    if (!allowed) {
+      throw new BadRequestException(`Invalid paramater 'path' ${filePath}`);
+    }
+
+    return filePath;
+  }
+
+  private validateDigitalOceanMetadataPath(filePath: string): string {
+    this.rejectHttpPath(filePath);
+
+    if (
+      filePath !== CloudProvidersMetaData.DIGITAL_OCEAN &&
+      filePath !== CloudProvidersMetaData.DIGITAL_OCEAN_JSON
+    ) {
+      throw new BadRequestException(`Invalid paramater 'path' ${filePath}`);
+    }
+
+    const allowed = Array.from(this.allowedDigitalOceanMetadataPaths).some((allowedPath) =>
+      filePath.endsWith(allowedPath)
+    );
+
+    if (!allowed) {
+      throw new BadRequestException(`Invalid paramater 'path' ${filePath}`);
+    }
+
+    return filePath;
+  }
+
   private async loadCPFile(cpBaseUrl: string, filePath: string) {
     if (cpBaseUrl === CloudProvidersMetaData.AWS) {
       filePath = this.validateAwsMetadataPath(filePath);
-    } else if (!filePath.startsWith(cpBaseUrl)) {
+    } else if (cpBaseUrl === CloudProvidersMetaData.AZURE) {
+      filePath = this.validateAzureMetadataPath(filePath);
+    } else if (cpBaseUrl === CloudProvidersMetaData.GOOGLE) {
+      filePath = this.validateGoogleMetadataPath(filePath);
+    } else if (cpBaseUrl === CloudProvidersMetaData.DIGITAL_OCEAN) {
+      filePath = this.validateDigitalOceanMetadataPath(filePath);
+    } else {
       throw new BadRequestException(`Invalid paramater 'path' ${filePath}`);
     }
 

--- a/src/file/file.controller.ts
+++ b/src/file/file.controller.ts
@@ -38,6 +38,32 @@ import { CloudProvidersMetaData } from './cloud.providers.metadata';
 @ApiTags('Files controller')
 export class FileController {
   private readonly logger = new Logger(FileController.name);
+  private readonly allowedAwsMetadataPaths = new Set<string>([
+    'ami-id',
+    'ami-launch-index',
+    'ami-manifest-path',
+    'block-device-mapping/',
+    'events/',
+    'hostname',
+    'iam/',
+    'instance-action',
+    'instance-id',
+    'instance-life-cycle',
+    'instance-type',
+    'local-hostname',
+    'local-ipv4',
+    'mac',
+    'metrics/',
+    'network/',
+    'placement/',
+    'profile',
+    'public-hostname',
+    'public-ipv4',
+    'public-keys/',
+    'reservation-id',
+    'security-groups',
+    'services/'
+  ]);
 
   constructor(private fileService: FileService) {}
 
@@ -49,12 +75,40 @@ export class FileController {
     }
   }
 
-  private async loadCPFile(cpBaseUrl: string, path: string) {
-    if (!path.startsWith(cpBaseUrl)) {
-      throw new BadRequestException(`Invalid paramater 'path' ${path}`);
+  private validateAwsMetadataPath(filePath: string): string {
+    if (!filePath || typeof filePath !== 'string') {
+      throw new BadRequestException(`Invalid paramater 'path' ${filePath}`);
     }
 
-    const file: Stream = await this.fileService.getFile(path);
+    if (filePath.startsWith('http://') || filePath.startsWith('https://')) {
+      throw new BadRequestException(`Invalid paramater 'path' ${filePath}`);
+    }
+
+    const prefix = CloudProvidersMetaData.AWS;
+    if (!filePath.startsWith(prefix)) {
+      throw new BadRequestException(`Invalid paramater 'path' ${filePath}`);
+    }
+
+    const metadataPath = filePath.substring(prefix.length);
+    const allowed = Array.from(this.allowedAwsMetadataPaths).some((allowedPath) =>
+      metadataPath === allowedPath || metadataPath.startsWith(allowedPath)
+    );
+
+    if (!allowed) {
+      throw new BadRequestException(`Invalid paramater 'path' ${filePath}`);
+    }
+
+    return filePath;
+  }
+
+  private async loadCPFile(cpBaseUrl: string, filePath: string) {
+    if (cpBaseUrl === CloudProvidersMetaData.AWS) {
+      filePath = this.validateAwsMetadataPath(filePath);
+    } else if (!filePath.startsWith(cpBaseUrl)) {
+      throw new BadRequestException(`Invalid paramater 'path' ${filePath}`);
+    }
+
+    const file: Stream = await this.fileService.getFile(filePath);
 
     return file;
   }

--- a/src/file/file.service.ts
+++ b/src/file/file.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import { Readable } from 'stream';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -13,18 +13,14 @@ export class FileService {
   async getFile(file: string): Promise<Readable> {
     this.logger.log(`Reading file: ${file}`);
 
+    if (this.isHttpUrl(file)) {
+      throw new BadRequestException('Remote URLs are not allowed');
+    }
+
     if (file.startsWith('/')) {
       await fs.promises.access(file, R_OK);
 
       return fs.createReadStream(file);
-    } else if (file.startsWith('http')) {
-      const content = await this.cloudProviders.get(file);
-
-      if (content) {
-        return Readable.from(content);
-      } else {
-        throw new Error(`no such file or directory, access '${file}'`);
-      }
     } else {
       file = path.resolve(process.cwd(), file);
 
@@ -37,12 +33,21 @@ export class FileService {
   async deleteFile(file: string): Promise<boolean> {
     if (file.startsWith('/')) {
       throw new Error('cannot delete file from this location');
-    } else if (file.startsWith('http')) {
+    } else if (this.isHttpUrl(file)) {
       throw new Error('cannot delete file from this location');
     } else {
       file = path.resolve(process.cwd(), file);
       await fs.promises.unlink(file);
       return true;
+    }
+  }
+
+  private isHttpUrl(file: string): boolean {
+    try {
+      const parsed = new URL(file);
+      return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+    } catch {
+      return false;
     }
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -192,8 +192,9 @@ async function bootstrap() {
     secret: randomBytes(32).toString('hex').slice(0, 32),
     cookieName: 'connect.sid',
     cookie: {
-      secure: false,
-      httpOnly: false
+      secure: process.env.NODE_ENV === 'production',
+      httpOnly: true,
+      sameSite: 'strict'
     }
   });
   server.addContentTypeParser('*', (req) => rawbody(req.raw));

--- a/src/mcp/mcp.controller.ts
+++ b/src/mcp/mcp.controller.ts
@@ -398,7 +398,9 @@ export class McpController {
 
     try {
       const result = await this.mcpService.readResource(params, {
-        authorizationHeader: session.authorizationHeader
+        authorizationHeader: session.authorizationHeader,
+        role: session.role,
+        authenticated: session.authenticated
       });
 
       return {
@@ -635,7 +637,9 @@ export class McpController {
     try {
       const result = await this.mcpService.callTool(params, {
         authorizationHeader: session.authorizationHeader,
-        onPartialOutput
+        onPartialOutput,
+        role: session.role,
+        authenticated: session.authenticated
       });
 
       return {

--- a/src/mcp/mcp.tool-executor.service.ts
+++ b/src/mcp/mcp.tool-executor.service.ts
@@ -98,8 +98,9 @@ export class McpToolExecutorService extends McpProxySupport {
         return this.proxyError('get_count', response);
       }
 
-      const text =
-        typeof response.data === 'string'
+      const text:
+        | string
+        = typeof response.data === 'string'
           ? response.data.trim()
           : String(response.data);
 
@@ -357,6 +358,18 @@ export class McpToolExecutorService extends McpProxySupport {
     authorizationHeader?: string
   ): Promise<McpToolResult> {
     try {
+      if (!authorizationHeader) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: 'Unauthorized: search_users requires an authenticated session'
+            }
+          ],
+          isError: true
+        };
+      }
+
       this.logger.debug('Proxy users search via /api/users/search/:name');
 
       const response = await axios.get(

--- a/src/mcp/mcp.tool-executor.service.ts
+++ b/src/mcp/mcp.tool-executor.service.ts
@@ -19,6 +19,8 @@ import { McpToolName } from './mcp.tool-registry';
 export interface McpToolExecutionContext {
   authorizationHeader?: string;
   onPartialOutput?: (chunk: McpToolPartialOutput) => void;
+  role?: 'user' | 'admin';
+  authenticated?: boolean;
 }
 
 export interface McpToolPartialOutput {
@@ -70,7 +72,8 @@ export class McpToolExecutorService extends McpProxySupport {
       case 'search_users':
         return this.executeSearchUsersTool(
           args as SearchUsersToolInput,
-          context.authorizationHeader
+          context.authorizationHeader,
+          context
         );
       case 'update_user':
         return this.executeUpdateUserTool(args as UpdateUserToolInput);
@@ -355,15 +358,44 @@ export class McpToolExecutorService extends McpProxySupport {
 
   private async executeSearchUsersTool(
     input: SearchUsersToolInput,
-    authorizationHeader?: string
+    authorizationHeader?: string,
+    context: McpToolExecutionContext = {}
   ): Promise<McpToolResult> {
     try {
-      if (!authorizationHeader) {
+      const isAdmin = context.role === 'admin';
+      const isAuthenticated = Boolean(authorizationHeader && context.authenticated !== false);
+
+      if (!isAuthenticated) {
         return {
           content: [
             {
               type: 'text',
-              text: 'Unauthorized: search_users requires an authenticated session'
+              text: 'Unauthorized: access denied'
+            }
+          ],
+          isError: true
+        };
+      }
+
+      if (!isAdmin) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: 'Forbidden: access denied'
+            }
+          ],
+          isError: true
+        };
+      }
+
+      const normalizedName = typeof input.name === 'string' ? input.name.trim() : '';
+      if (!normalizedName.length) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: 'Invalid arguments'
             }
           ],
           isError: true
@@ -373,7 +405,7 @@ export class McpToolExecutorService extends McpProxySupport {
       this.logger.debug('Proxy users search via /api/users/search/:name');
 
       const response = await axios.get(
-        this.endpoint(`/api/users/search/${encodeURIComponent(input.name)}`),
+        this.endpoint(`/api/users/search/${encodeURIComponent(normalizedName)}`),
         {
           headers: {
             ...this.buildProxyHeaders(authorizationHeader),
@@ -385,7 +417,15 @@ export class McpToolExecutorService extends McpProxySupport {
       );
 
       if (response.status !== 200) {
-        return this.proxyError('search_users', response);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: 'Forbidden: access denied'
+            }
+          ],
+          isError: true
+        };
       }
 
       return {
@@ -398,7 +438,7 @@ export class McpToolExecutorService extends McpProxySupport {
       };
     } catch (error) {
       return {
-        content: [{ type: 'text', text: `Error: ${(error as Error).message}` }],
+        content: [{ type: 'text', text: 'Forbidden: access denied' }],
         isError: true
       };
     }

--- a/src/mcp/mcp.tool-registry.ts
+++ b/src/mcp/mcp.tool-registry.ts
@@ -177,7 +177,7 @@ export const MCP_TOOL_REGISTRY: Record<McpToolName, McpToolRegistration> = {
       name: 'search_users',
       description:
         'Proxy to /api/users/search/:name. Returns a JSON array of matching users.',
-      accessLevel: 'public',
+      accessLevel: 'authenticated',
       inputSchema: {
         type: 'object',
         properties: {

--- a/src/testimonials/testimonials.controller.ts
+++ b/src/testimonials/testimonials.controller.ts
@@ -2,7 +2,6 @@ import {
   Body,
   Controller,
   Get,
-  Header,
   Logger,
   Post,
   Query,
@@ -89,10 +88,9 @@ export class TestimonialsController {
   @Get('count')
   @ApiQuery({
     name: 'query',
-    example: 'select count(*) as count from testimonial',
+    example: 'testimonial',
     required: true
   })
-  @Header('content-type', 'text/html')
   @ApiOperation({
     description: API_DESC_GET_TESTIMONIALS_ON_SQL_QUERY
   })

--- a/src/testimonials/testimonials.service.ts
+++ b/src/testimonials/testimonials.service.ts
@@ -56,12 +56,28 @@ export class TestimonialsService {
 
   async count(query: string): Promise<number> {
     try {
-      this.logger.debug(`Saved new testimonial`);
+      this.logger.debug(`Count testimonials using allowlisted input`);
 
-      return (await this.em.getConnection().execute(query))[0].count as number;
+      const allowedQueries = new Map<string, string>([
+        ['testimonial', 'select count(*) as count from testimonial'],
+        ['all', 'select count(*) as count from testimonial']
+      ]);
+
+      const normalizedQuery = (query ?? '').trim().toLowerCase();
+      const sql = allowedQueries.get(normalizedQuery);
+
+      if (!sql) {
+        throw new Error('Invalid count query');
+      }
+
+      const result = await this.em.getConnection().execute(sql);
+      const countValue = result?.[0]?.count;
+
+      return typeof countValue === 'number' ? countValue : Number(countValue) || 0;
     } catch (err) {
-      this.logger.warn(`Failed to execute query. Error: ${err.message}`);
-      return err.message;
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      this.logger.warn(`Failed to count testimonials. Error: ${message}`);
+      throw new Error('Failed to count testimonials');
     }
   }
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -119,6 +119,8 @@ export class UsersController {
   }
 
   @Get('/id/:id')
+  @UseGuards(AuthGuard)
+  @JwtType(JwtProcessorType.RSA)
   @ApiQuery({ name: 'id', example: 1, required: true })
   @SerializeOptions({ groups: [BASIC_USER_INFO] })
   @ApiOperation({
@@ -126,7 +128,18 @@ export class UsersController {
   })
   @ApiOkResponse({
     type: UserDto,
-    description: 'Returns basic user info if it exists'
+    description: 'Returns basic user info if authorized'
+  })
+  @ApiForbiddenResponse({
+    description: 'invalid credentials',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number' },
+        message: { type: 'string' },
+        error: { type: 'string' }
+      }
+    }
   })
   @ApiNotFoundResponse({
     description: 'User not found',
@@ -138,10 +151,25 @@ export class UsersController {
       }
     }
   })
-  async getById(@Param('id') id: number): Promise<UserDto> {
+  async getById(
+    @Param('id') id: string,
+    @Req() req: FastifyRequest
+  ): Promise<UserDto> {
     try {
-      this.logger.debug(`Find a user by id: ${id}`);
-      return new UserDto(await this.usersService.findById(id));
+      const requestedId = Number(id);
+      if (!Number.isInteger(requestedId) || requestedId <= 0) {
+        throw new NotFoundException('User not found');
+      }
+
+      const email = this.originEmail(req);
+      const currentUser = await this.usersService.findByEmail(email);
+
+      if (currentUser.id !== requestedId) {
+        throw new ForbiddenException();
+      }
+
+      this.logger.debug(`Find a user by id: ${requestedId}`);
+      return new UserDto(currentUser);
     } catch (err) {
       throw new HttpException(err.message, err.status);
     }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -177,6 +177,8 @@ export class UsersController {
   }
 
   @Get('/search/:name')
+  @UseGuards(AuthGuard)
+  @JwtType(JwtProcessorType.RSA)
   @ApiQuery({ name: 'name', example: 'john', required: true })
   @SerializeOptions({ groups: [FULL_USER_INFO] })
   @ApiOperation({
@@ -185,6 +187,17 @@ export class UsersController {
   @ApiOkResponse({
     type: UserDto,
     description: SWAGGER_DESC_FIND_USERS
+  })
+  @ApiForbiddenResponse({
+    description: 'invalid credentials',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number' },
+        message: { type: 'string' },
+        error: { type: 'string' }
+      }
+    }
   })
   async searchByName(@Param('name') name: string): Promise<UserDto[]> {
     try {

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -125,9 +125,15 @@ export class UsersService {
 
   async searchByName(query: string, limit?: number): Promise<User[]> {
     this.log.debug(`Called searchUsersByName`);
+
+    const normalizedQuery = typeof query === 'string' ? query.trim() : '';
+    if (!normalizedQuery.length) {
+      return [];
+    }
+
     return this.usersRepository.find(
       {
-        firstName: { $like: query + '%' }
+        firstName: { $like: normalizedQuery }
       },
       limit ? { limit } : {}
     );


### PR DESCRIPTION
## 🛡️ Bright Security Scan

✅ **Analyzing repository for tech stack and HTTP endpoints**
   - Tech stack: TypeScript, JavaScript, SQL, NestJS, React, Vite, Fastify
   - Found 75 HTTP endpoints
✅ **Starting the application under test**
   - Application running at http://localhost:3000
✅ **Setting up Bright security scanner and Repeater**
   - Repeater connected: eJYcBiWrq8Q3Jc6i8Af5tQ
✅ **Detecting authentication requirements**
   - Auth configured: tBHuxEHgSrmgtjue8ZmeXi
✅ **Registering API endpoints for scanning**
   - Registered 57 entrypoints
   - 51 live entrypoints after pruning 404s
✅ **Selecting relevant security tests per endpoint**
   - Created 10 scan group(s) with per-endpoint test selection
✅ **Running scans — round 1**
   - Round 1 complete — 24 vulnerabilities found (4 Critical, 11 High, 9 Medium)
✅ **Fixing 24 vulnerabilities — round 1**
   - Applied 24 fix(es) across 54 file(s), restarting for validation...
   - Medium — Exposed Common File - config.js: Blocked public access to the sensitive config.js file at the web server layer and removed secret-bearing content from the public config file by replacing it with a safe non-exporting placeholder.
   - Medium — Exposed Common File - nginx.conf: Removed the exposed deployment config from the frontend public assets and hardened static serving so only intended files are accessible.
   - Medium — Exposed Common File - .htaccess: Disabled dotfile serving in Fastify static configuration to prevent direct access to exposed files like .htaccess.
   - Medium — Exposed Common File - .env: Disabled dotfile serving in Fastify static config, restricted access to hidden files in nginx, and removed serving of dotfiles from public static routes to prevent /.env exposure.
   - Medium — HTML Injection: Removed unsafe HTML response handling and eliminated arbitrary SQL execution from the testimonials count endpoint by switching to a fixed, parameterless count query and returning a numeric JSON response only.
   - High — Cross-Site Scripting: Replaced unsafe user-controlled SQL execution with an allowlisted count operation, removed HTML response typing, and stopped returning raw error messages to prevent XSS and SQL injection in REST and GraphQL paths.
   - High — [BL] ID Enumeration: Restricted user search to authenticated/admin MCP sessions and removed the enumerating search endpoint from public access. The MCP proxy now rejects unauthorized search_users calls before forwarding them, and the users search endpoint returns a uniform response path only for authorized callers.
   - Critical — Remote File Inclusion: Removed remote URL fetching from file retrieval, added strict local-path allowlisting/normalization to prevent remote file inclusion, and validated response MIME types against a safe allowlist.
   - High — Server Side Request Forgery: Restricted file loading to safe local paths and approved cloud metadata endpoints, removing arbitrary URL fetching to prevent SSRF.
   - High — Local File Inclusion: Restricted file operations to an allowlisted base directory and removed direct handling of attacker-controlled absolute paths/relative traversal in file reads, writes, and deletes. Added input validation at the controller boundary and centralized safe path resolution in the service.
   - High — Server Side Request Forgery: Removed arbitrary server-side URL fetching from the file download flow and added boundary validation to block remote URLs on the raw file endpoint. Cloud metadata access is now strictly allowlisted to known provider base URLs only, preventing SSRF.
   - Critical — MongoDB Injection: Hardened the email retrieval endpoint by validating the `withSource` query parameter as a strict boolean and rejecting unexpected query-object shapes, preventing query-operator style injection patterns from being propagated further. No MongoDB query sink exists in the traced code path, so the fix focuses on boundary validation for this endpoint.
   - High — Local File Inclusion: Removed unsafe raw filesystem path handling and replaced it with allowlisted, normalized paths restricted to the application working directory. The controller now validates user-supplied paths at the boundary, and the service rejects absolute paths, traversal attempts, and non-allowlisted file access for read/delete/upload operations.
   - Critical — Remote File Inclusion: Removed the remote URL fetch path from file reads and added input validation to reject http/https targets in the raw file endpoint. The service now only serves local filesystem paths, preventing remote file inclusion.
   - Medium — Cross-Site Request Forgery (CSRF): Hardened the email retrieval endpoint against CSRF by requiring a CSRF token and validating the request Origin/Referer against the application's own origin. Also strengthened session cookies to use SameSite=Strict and HttpOnly, with Secure enabled in production.
   - High — Server Side Request Forgery: Removed the SSRF sink by restricting cloud-provider file reads to fixed allowlisted metadata paths and eliminating arbitrary URL fetches. Added boundary validation in the controller and service so only known provider resources can be requested.
   - High — Server Side Request Forgery: Removed SSRF-prone arbitrary URL fetching and replaced it with strict allowlisted metadata path handling for provider endpoints, with validation at the controller boundary and provider URL normalization in the service.
   - High — Server Side Request Forgery: Removed arbitrary outbound URL fetching and replaced prefix-based SSRF checks with strict URL parsing and allowlisted metadata paths for cloud-provider file reads.
   - High — Server Side Request Forgery: Fixed SSRF by removing arbitrary URL fetching and enforcing strict allowlists for cloud-metadata paths. The AWS endpoint now only accepts known safe metadata entries, and the metadata provider no longer performs fallback outbound requests for user-controlled URLs.
   - High — Broken JWT Authentication: Enforced strict RS256 verification for the RSA signature JWT path and removed unsafe alg=none acceptance from the HMAC processor to prevent authentication bypass. The token parser logging was also adjusted to avoid implying None-alg acceptance.
   - Critical — Server Side Template Injection: Removed server-side template execution from /api/render by replacing user-controlled template compilation with a fixed allowlisted template mapping. User input is now treated as plain data and safely encoded before rendering.
   - Medium — Unvalidated Redirect: Added allowlist-based validation to the redirect endpoint so only approved HTTP(S) destinations can be used, preventing open redirects.
   - Medium — Secret Tokens Leak: Removed the hardcoded secret disclosure endpoint behavior and replaced it with a safe error response, preventing public exposure of embedded tokens from the API.
   - Medium — Secret Tokens Leak: Removed public exposure of sensitive configuration and hardcoded secret tokens. The /api/config endpoint now returns only non-sensitive public fields, and the /api/secrets endpoint no longer leaks embedded tokens.
✅ **Running scans — round 2**
   - Round 2 complete — 13 vulnerabilities found (1 Critical, 10 High, 2 Medium)
✅ **Fixing 13 vulnerabilities — round 2**
   - Applied 13 fix(es) across 35 file(s), restarting for validation...
   - High — [BL] ID Enumeration: Applied defense-in-depth fixes to stop user ID enumeration at multiple layers: the MCP search tool is now disabled for non-admin sessions, the users search endpoint is admin-only and refuses to disclose existence via search semantics, and the service no longer performs prefix-based discovery. Responses are normalized to avoid leaking whether identifiers are valid.
   - High — Server Side Request Forgery: Hardened all file-serving entry points with strict path validation and removed any HTTP/URL-based fetching from the generic file loader and service layer. Added allowlist-based handling for cloud-provider metadata paths so attacker-controlled URLs can no longer trigger outbound requests, closing the SSRF across controller, service, and gRPC paths.
   - High — Local File Inclusion: Reworked file access to use an explicit server-side allowlist mapping instead of accepting user-controlled filesystem paths. The API now resolves only approved file keys, blocks absolute/relative traversal inputs at the controller boundary, and removes direct path-based read/delete/write behavior from the service.
   - High — Server Side Request Forgery: Applied defense-in-depth SSRF remediation by removing remote URL fetching from the generic file-read path, validating and allowlisting only local filesystem paths for /api/file/raw, and ensuring cloud-provider endpoints can only reach strict provider metadata base URLs. This blocks attacker-controlled http/https input across all exposed read paths.
   - High — Local File Inclusion: Applied a stricter allowlist-based fix by removing direct filesystem access from user-controlled endpoints and constraining file operations to a predefined safe directory tree. The controller now validates raw paths at the boundary, and the service only resolves normalized relative paths within the safe base directory, eliminating absolute-path and traversal reads/writes that could lead to LFI.
   - High — Server Side Request Forgery: Applied defense-in-depth SSRF remediation by removing all user-controlled remote fetch behavior from the file service, replacing metadata URL handling with strict provider/path allowlists, and validating every cloud-provider endpoint at the controller boundary. This blocks metadata URL injection across HTTP and gRPC paths.
   - High — Server Side Request Forgery: Implemented strict metadata-path allowlisting at the controller boundary and removed all arbitrary URL handling from the file retrieval flow. The DigitalOcean endpoint now only accepts exact known metadata resource names or safe subpaths, and the service/provider layers no longer treat attacker input as a URL target.
   - High — Server Side Request Forgery: Applied defense-in-depth SSRF remediation by removing URL-based remote fetching from FileService, adding strict allowlisted cloud-metadata path validation in the controller, and hard-blocking any HTTP(S) paths from reaching the file reader across all file endpoints.
   - High — Broken JWT Authentication: Hardened JWT verification at the guard layer by enforcing strict algorithm allowlisting and rejecting malformed bearer tokens before they reach any processor. The RSA signature processor now performs explicit structural and cryptographic verification using a dedicated JWT library instead of relying on jwt-simple’s permissive decode path, eliminating signature-manipulation bypasses on the validate endpoint.
   - Critical — Server Side Template Injection: Reworked the /api/render endpoint to eliminate SSTI by removing all template compilation/execution on user-controlled input. The endpoint now validates an optional allowlisted mode and renders only fixed server-side templates with escaped user data, preventing attacker-supplied template syntax from reaching the templating engine.
   - Medium — Unvalidated Redirect: Reworked the redirect endpoint to use a strict allowlist and a safe internal redirect path. Untrusted URLs are now rejected, and only approved external destinations or a fixed local fallback are permitted.
   - High — [BL] ID Enumeration: Added server-side authorization to the user-by-ID endpoint so only the authenticated user can access their own record, and the endpoint no longer leaks user existence through ID-based lookup responses to unauthorized callers.
   - Medium — Secret Tokens Leak: Hardened configuration exposure by requiring authentication for /api/config, removing all secret-bearing fields from the public config DTO, and ensuring the config response only returns explicitly allowlisted public values. Also replaced the secrets endpoint response with a no-op message to avoid accidental leakage.
✅ **Running scans — round 3**
🔄 **One or more scans failed on round 3. Check Bright dashboard.**