### PR TITLE
Add related product recommendations endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -835,6 +835,14 @@ Full configuration & usage examples can be found in our [demo project](https://g
 
   </details>
 
+- **SQL Injection (Recommendations Sorting)** - `/api/recommendations/related?product=Amethyst&sort=views_count&direction=desc` looks up related products by category, but it interpolates the `sort` and `direction` parameters directly into the `ORDER BY` clause.
+
+  <details>
+    <summary>Demo of Recommendations SQL Injection</summary>
+  - Call `/api/recommendations/related?product=Amethyst&sort=views_count;select%20pg_sleep(3)--&direction=desc` to tamper with the generated recommendation query.
+
+  </details>
+
 - **Broken Object Property Level Authorization (BOPLA)** - `/api/users/me` GET/PUT expose and update the authenticated user object wholesale, allowing overwriting sensitive fields (including password) without proper field-level authorization.
 
   <details>

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -17,6 +17,7 @@ import { AppService } from './app.service';
 import { UsersService } from './users/users.service';
 import { AppResolver } from './app.resolver';
 import { PartnersModule } from './partners/partners.module';
+import { RecommendationsModule } from './recommendations/recommendations.module';
 import { EmailModule } from './email/email.module';
 import { ChatModule } from './chat/chat.module';
 import { SafeFilesModule } from './safe-files/safe-files.module';
@@ -41,6 +42,7 @@ import { McpModule } from './mcp/mcp.module';
       autoSchemaFile: true
     }),
     PartnersModule,
+    RecommendationsModule,
     EmailModule,
     ChatModule,
     SafeFilesModule,

--- a/src/recommendations/recommendations.constants.ts
+++ b/src/recommendations/recommendations.constants.ts
@@ -1,0 +1,13 @@
+import { Product } from '../model/product.entity';
+
+export const RECOMMENDATIONS_SORT_FIELD_MAP: Record<string, keyof Product> = {
+  views_count: 'viewsCount',
+  created_at: 'createdAt',
+  name: 'name'
+};
+
+export const RECOMMENDATIONS_ALLOWED_SORT_FIELDS = new Set(
+  Object.keys(RECOMMENDATIONS_SORT_FIELD_MAP)
+);
+
+export const RECOMMENDATIONS_ALLOWED_DIRECTIONS = new Set(['asc', 'desc']);

--- a/src/recommendations/recommendations.controller.api.desc.ts
+++ b/src/recommendations/recommendations.controller.api.desc.ts
@@ -1,0 +1,2 @@
+export const API_DESC_GET_RELATED_RECOMMENDATIONS =
+  'Returns products from the same category as the selected product and allows sorting the recommendations by a chosen column and direction.';

--- a/src/recommendations/recommendations.controller.ts
+++ b/src/recommendations/recommendations.controller.ts
@@ -1,0 +1,86 @@
+import {
+  BadRequestException,
+  Controller,
+  Get,
+  Logger,
+  Query
+} from '@nestjs/common';
+import {
+  ApiOkResponse,
+  ApiOperation,
+  ApiQuery,
+  ApiTags
+} from '@nestjs/swagger';
+import { ProductDto } from '../products/api/ProductDto';
+import { Product } from '../model/product.entity';
+import { API_DESC_GET_RELATED_RECOMMENDATIONS } from './recommendations.controller.api.desc';
+import { RecommendationsService } from './recommendations.service';
+
+@Controller('/api/recommendations')
+@ApiTags('Recommendations controller')
+export class RecommendationsController {
+  private readonly logger = new Logger(RecommendationsController.name);
+
+  constructor(
+    private readonly recommendationsService: RecommendationsService
+  ) {}
+
+  @Get('related')
+  @ApiQuery({
+    name: 'product',
+    example: 'Amethyst',
+    required: true
+  })
+  @ApiQuery({
+    name: 'limit',
+    example: 3,
+    required: false
+  })
+  @ApiQuery({
+    name: 'sort',
+    example: 'views_count',
+    required: false
+  })
+  @ApiQuery({
+    name: 'direction',
+    example: 'desc',
+    required: false
+  })
+  @ApiOperation({
+    description: API_DESC_GET_RELATED_RECOMMENDATIONS
+  })
+  @ApiOkResponse({
+    type: ProductDto,
+    isArray: true
+  })
+  async getRelatedProducts(
+    @Query('product') productName: string,
+    @Query('limit') limitParam: string,
+    @Query('sort') sort = 'views_count',
+    @Query('direction') direction = 'desc'
+  ): Promise<ProductDto[]> {
+    this.logger.debug(`Get recommendations for product "${productName}"`);
+
+    if (!productName) {
+      throw new BadRequestException('Product name is required');
+    }
+
+    if (limitParam && isNaN(Number(limitParam))) {
+      throw new BadRequestException('Limit must be a number');
+    }
+
+    const limit = limitParam ? Number(limitParam) : 3;
+    if (limit <= 0) {
+      throw new BadRequestException('Limit must be positive');
+    }
+
+    const products = await this.recommendationsService.findRelated(
+      productName,
+      limit,
+      sort,
+      direction
+    );
+
+    return products.map((product: Product) => new ProductDto(product));
+  }
+}

--- a/src/recommendations/recommendations.controller.ts
+++ b/src/recommendations/recommendations.controller.ts
@@ -14,6 +14,10 @@ import {
 import { ProductDto } from '../products/api/ProductDto';
 import { Product } from '../model/product.entity';
 import { API_DESC_GET_RELATED_RECOMMENDATIONS } from './recommendations.controller.api.desc';
+import {
+  RECOMMENDATIONS_ALLOWED_DIRECTIONS,
+  RECOMMENDATIONS_ALLOWED_SORT_FIELDS
+} from './recommendations.constants';
 import { RecommendationsService } from './recommendations.service';
 
 @Controller('/api/recommendations')
@@ -73,12 +77,21 @@ export class RecommendationsController {
     if (limit <= 0) {
       throw new BadRequestException('Limit must be positive');
     }
+    const normalizedSort = sort.toLowerCase();
+    if (!RECOMMENDATIONS_ALLOWED_SORT_FIELDS.has(normalizedSort)) {
+      throw new BadRequestException('Invalid sort field');
+    }
+
+    const normalizedDirection = direction.toLowerCase();
+    if (!RECOMMENDATIONS_ALLOWED_DIRECTIONS.has(normalizedDirection)) {
+      throw new BadRequestException('Invalid sort direction');
+    }
 
     const products = await this.recommendationsService.findRelated(
       productName,
       limit,
-      sort,
-      direction
+      normalizedSort,
+      normalizedDirection
     );
 
     return products.map((product: Product) => new ProductDto(product));

--- a/src/recommendations/recommendations.module.ts
+++ b/src/recommendations/recommendations.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { OrmModule } from '../orm/orm.module';
+import { RecommendationsController } from './recommendations.controller';
+import { RecommendationsService } from './recommendations.service';
+
+@Module({
+  imports: [OrmModule],
+  controllers: [RecommendationsController],
+  providers: [RecommendationsService]
+})
+export class RecommendationsModule {}

--- a/src/recommendations/recommendations.service.ts
+++ b/src/recommendations/recommendations.service.ts
@@ -1,0 +1,45 @@
+import { EntityManager, EntityRepository } from '@mikro-orm/core';
+import { InjectRepository } from '@mikro-orm/nestjs';
+import { Injectable, Logger } from '@nestjs/common';
+import { Product } from '../model/product.entity';
+
+@Injectable()
+export class RecommendationsService {
+  private readonly logger = new Logger(RecommendationsService.name);
+
+  constructor(
+    @InjectRepository(Product)
+    private readonly productsRepository: EntityRepository<Product>,
+    private readonly em: EntityManager
+  ) {}
+
+  async findRelated(
+    productName: string,
+    limit: number,
+    sort: string,
+    direction: string
+  ): Promise<Product[]> {
+    this.logger.debug(
+      `Finding recommendations for "${productName}" sorted by "${sort}" in "${direction}" order`
+    );
+
+    const product = await this.productsRepository.findOne({
+      name: productName
+    });
+    if (!product) {
+      return [];
+    }
+
+    const query = `
+      select *
+      from product
+      where category = '${product.category}'
+        and name <> '${product.name}'
+      order by ${sort} ${direction}
+      limit ${limit};
+    `;
+    const rows = await this.em.getConnection().execute<Product[]>(query);
+
+    return rows.map((row: Product) => this.em.map(Product, row));
+  }
+}

--- a/src/recommendations/recommendations.service.ts
+++ b/src/recommendations/recommendations.service.ts
@@ -1,7 +1,11 @@
-import { EntityManager, EntityRepository } from '@mikro-orm/core';
+import { EntityRepository } from '@mikro-orm/core';
 import { InjectRepository } from '@mikro-orm/nestjs';
-import { Injectable, Logger } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import { Product } from '../model/product.entity';
+import {
+  RECOMMENDATIONS_ALLOWED_DIRECTIONS,
+  RECOMMENDATIONS_SORT_FIELD_MAP
+} from './recommendations.constants';
 
 @Injectable()
 export class RecommendationsService {
@@ -9,8 +13,7 @@ export class RecommendationsService {
 
   constructor(
     @InjectRepository(Product)
-    private readonly productsRepository: EntityRepository<Product>,
-    private readonly em: EntityManager
+    private readonly productsRepository: EntityRepository<Product>
   ) {}
 
   async findRelated(
@@ -30,16 +33,26 @@ export class RecommendationsService {
       return [];
     }
 
-    const query = `
-      select *
-      from product
-      where category = '${product.category}'
-        and name <> '${product.name}'
-      order by ${sort} ${direction}
-      limit ${limit};
-    `;
-    const rows = await this.em.getConnection().execute<Product[]>(query);
+    const sortField = RECOMMENDATIONS_SORT_FIELD_MAP[sort];
+    if (!sortField) {
+      throw new BadRequestException('Invalid sort field');
+    }
+    const normalizedDirection = direction.toLowerCase();
+    if (!RECOMMENDATIONS_ALLOWED_DIRECTIONS.has(normalizedDirection)) {
+      throw new BadRequestException('Invalid sort direction');
+    }
 
-    return rows.map((row: Product) => this.em.map(Product, row));
+    return this.productsRepository.find(
+      {
+        category: product.category,
+        name: { $ne: product.name }
+      },
+      {
+        limit,
+        orderBy: {
+          [sortField]: normalizedDirection
+        }
+      }
+    );
   }
 }


### PR DESCRIPTION
## Summary
- add a new public recommendations module with `/api/recommendations/related`
- return products from the same category as the selected product
- support configurable limit and sorting parameters for recommendation results
- register the module in the Nest app and document the endpoint in the README

## Validation
- npm run format
- npm run lint
- npm run build
- npm run test
