### PR TITLE
ci: add Bright Agent DAST workflow

### DIFF
--- a/.github/workflows/bright-agent.yml
+++ b/.github/workflows/bright-agent.yml
@@ -1,0 +1,149 @@
+# Bright Agent — GitHub Actions workflow for Broken Crystals
+#
+# Agentic DAST: checks out this repo, boots the app via Docker Compose
+# (compose.local.yml), scans the live endpoints, and commits/PRs verified fixes.
+#
+# The agent only runs when you explicitly ask for it:
+#
+#   • issue_comment     → a repo OWNER / MEMBER / COLLABORATOR comments
+#                         `/bright-agent <guidance>` (lowercase) on a PR; runs
+#                         that PR with the guidance routed to the right phase
+#                         (commits fixes to its head branch, sticky comment,
+#                         "Bright Agent" status).
+#   • workflow_dispatch → manual scan, launched by hand on a chosen branch.
+#
+# Runner prerequisites: Docker, Docker Compose, Git, curl, sha256sum (all on
+# GitHub-hosted `ubuntu-latest`).
+#
+# Required repository secrets:
+#     BRIGHT_TOKEN      Bright API token from https://app.brightsec.com
+#     INFERENCE_TOKEN   API token for your OpenAI-compatible inference endpoint
+#   and one repository variable:
+#     INFERENCE_URL     that endpoint's base URL (OpenAI, GitHub Models, Ollama, …)
+#
+# Repo access uses the built-in GITHUB_TOKEN (see `permissions:`).
+#
+# IMPORTANT for steering: GitHub only triggers `issue_comment` workflows from
+# the file on your repo's DEFAULT branch — so this workflow must be merged to
+# the default branch for `/bright-agent` replies to work.
+
+name: Bright Agent (DAST)
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch: {}
+
+# contents: write     → commit fixes onto the (PR head or scan) branch
+# pull-requests: write → open/update the PR + summary comment + reactions
+# statuses: write     → set the "Bright Agent" commit status
+permissions:
+  contents: write
+  pull-requests: write
+  statuses: write
+
+# One run per PR (its /bright-agent replies); else per ref (manual dispatch).
+concurrency:
+  group: bright-agent-${{ github.event.issue.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bright-agent:
+    # Trigger gates:
+    #  • issue_comment: a lowercase `/bright-agent` comment from a repo
+    #                   OWNER / MEMBER / COLLABORATOR on a PR.
+    #  • workflow_dispatch: always (manual run on a chosen branch).
+    if: >-
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, '/bright-agent') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    env:
+      # Runner platform/arch: linux-x64 | linux-arm64 | darwin-x64 | darwin-arm64
+      ASSET: bright-agent-linux-x64
+    steps:
+      # For a `/bright-agent` comment: resolve the PR over the API and REFUSE
+      # fork PRs BEFORE any checkout. issue_comment runs in the base-repo context
+      # with secrets in scope, so checking out and running a fork's head would
+      # leak them. Outputs the head/base refs the run binds to.
+      - name: Resolve steering PR (refuse forks)
+        id: steer
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            const sameRepo =
+              pr.head.repo &&
+              pr.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`;
+            if (!sameRepo) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body:
+                  "🔒 `/bright-agent` steering is not available on fork PRs for " +
+                  "security reasons (it would run untrusted code with repository " +
+                  "secrets). Push the branch to this repository to use it.",
+              });
+              core.setFailed("Steering disabled on fork PRs.");
+              return;
+            }
+            core.setOutput("head_ref", pr.head.ref);
+            core.setOutput("base_ref", pr.base.ref);
+
+      # Check out the tree to scan. /bright-agent comment → the PR head branch
+      # (so fixes commit back to it); manual dispatch → the chosen ref. Download
+      # the binary OUTSIDE this checkout so it's never swept into a fix commit.
+      - uses: actions/checkout@v5
+        with:
+          ref: >-
+            ${{ (github.event_name == 'issue_comment' && steps.steer.outputs.head_ref)
+              || github.ref }}
+          fetch-depth: 0
+
+      - name: Download & verify Bright Agent
+        working-directory: ${{ runner.temp }}
+        run: |
+          # Latest release. To pin a version, replace 'latest/download' with
+          # 'download/<tag>', e.g. .../releases/download/v0.1.1
+          base="https://github.com/NeuraLegion/bright-agent-dist/releases/latest/download"
+          curl -fsSL -o "${ASSET}" "${base}/${ASSET}"
+          curl -fsSL -o "${ASSET}.sha256" "${base}/${ASSET}.sha256"
+          sha256sum -c "${ASSET}.sha256"
+          chmod +x "${ASSET}"
+
+      - name: Run Bright Agent
+        env:
+          # Run against the checked-out tree. REPOSITORY_URL is derived from the
+          # checkout's `origin` remote (set REPOSITORY_URL to override).
+          LOCAL_REPO_PATH: ${{ github.workspace }}
+          REPO_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRIGHT_TOKEN: ${{ secrets.BRIGHT_TOKEN }}
+          INFERENCE_URL: ${{ vars.INFERENCE_URL }}
+          INFERENCE_TOKEN: ${{ secrets.INFERENCE_TOKEN }}
+          # Steering inputs — populated only for a `/bright-agent` comment; empty
+          # for every other trigger, so the agent runs a normal scan.
+          BRIGHT_STEERING_COMMENT: ${{ github.event_name == 'issue_comment' && github.event.comment.body || '' }}
+          BRIGHT_STEERING_COMMENT_ID: ${{ github.event_name == 'issue_comment' && github.event.comment.id || '' }}
+          BRIGHT_STEERING_AUTHOR: ${{ github.event_name == 'issue_comment' && github.event.comment.user.login || '' }}
+          BRIGHT_STEERING_AUTHOR_ASSOCIATION: ${{ github.event_name == 'issue_comment' && github.event.comment.author_association || '' }}
+          BRIGHT_STEERING_PR_NUMBER: ${{ github.event_name == 'issue_comment' && github.event.issue.number || '' }}
+          BRIGHT_STEERING_PR_HEAD: ${{ steps.steer.outputs.head_ref }}
+          BRIGHT_STEERING_PR_BASE: ${{ steps.steer.outputs.base_ref }}
+          # Optional:
+          # AI_MODEL: gpt-5.4-mini
+          # SCAN_SCOPE: full      # force a full-repo scan even on a PR
+          # BRIGHT_DEBUG: "1"
+        run: "${{ runner.temp }}/${{ env.ASSET }}"
+
+# NOTE: commits/PRs/comments made with GITHUB_TOKEN do not trigger your other
+# workflows (GitHub's anti-recursion rule). To have fix commits re-run your
+# repo's CI (check.yml / check-client.yml), use a PAT instead:
+#     REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/bright-agent.yml` — a Bright Agent (agentic DAST) workflow for Broken Crystals.
- Runs **only on explicit request**, never automatically:
  - `workflow_dispatch` — manual run on a chosen branch from the Actions tab.
  - `issue_comment` — a `/bright-agent <guidance>` comment from an OWNER/MEMBER/COLLABORATOR on a PR.
- No `schedule` (cron) and no `pull_request` auto-trigger.
- The agent boots the app via Docker Compose, scans live endpoints, and commits/PRs verified fixes.

## Required configuration
Set in **Settings → Secrets and variables → Actions**:
- Secrets: `BRIGHT_TOKEN`, `INFERENCE_TOKEN`
- Variable: `INFERENCE_URL` (e.g. `https://api.openai.com/v1`)

Repo access uses the built-in `GITHUB_TOKEN`.

> Note: for `/bright-agent` comment steering to work, this workflow must land on the default branch (`stable`), since GitHub only triggers `issue_comment` from the default-branch copy.

## Test plan
- [ ] Merge to `stable`, then trigger a manual run via Actions → "Bright Agent (DAST)" → Run workflow.
- [ ] Comment `/bright-agent` on a same-repo PR and confirm the agent picks it up.

Made with [Cursor](https://cursor.com)