### PR TITLE
🛡️ Bright Security Scan

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -247,8 +247,15 @@ export class AppController {
   async getCommandResultGrpc(data: {
     command: string;
   }): Promise<{ output: string }> {
-    const output = await this.appService.launchCommand(data.command);
-    return { output };
+    try {
+      const output = await this.appService.launchCommand(data.command);
+      return { output };
+    } catch (err) {
+      throw new InternalServerErrorException({
+        error: err.message || err,
+        location: __filename
+      });
+    }
   }
 
   @Get('/config')

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -7,6 +7,16 @@ import { OrmModuleConfigProperties } from './orm/orm.module.config.properties';
 import { AppConfig } from './app.config.api';
 import { UserDto } from './users/api/UserDto';
 
+// Strict allow-list of binaries that are permitted to be executed via the
+// "launch command" demo feature. Only these executables may be run, and
+// only with arguments that pass the safe-argument validation below.
+const ALLOWED_COMMANDS: ReadonlySet<string> = new Set(['ls', 'pwd', 'whoami', 'date', 'echo']);
+
+// Only allow simple alphanumeric arguments (plus a few harmless punctuation
+// characters commonly used in flags/paths). Anything else -- including shell
+// metacharacters such as ; | & $ ( ) ` > < and newlines -- is rejected.
+const SAFE_ARG_REGEX = /^[a-zA-Z0-9_.\-/]*$/;
+
 @Injectable()
 export class AppService {
   private readonly logger = new Logger(AppService.name);
@@ -19,10 +29,24 @@ export class AppService {
   async launchCommand(command: string): Promise<string> {
     this.logger.debug(`launch ${command} command`);
 
+    if (typeof command !== 'string' || command.trim().length === 0) {
+      throw new Error('Invalid command');
+    }
+
+    const parts = command.trim().split(/\s+/).filter(Boolean);
+    const [exec, ...args] = parts;
+
+    if (!exec || !ALLOWED_COMMANDS.has(exec)) {
+      throw new Error('Command is not allowed');
+    }
+
+    if (!args.every((arg) => SAFE_ARG_REGEX.test(arg))) {
+      throw new Error('Command arguments contain invalid characters');
+    }
+
     return new Promise((res, rej) => {
       try {
-        const [exec, ...args] = command.split(' ');
-        const ps = spawn(exec, args);
+        const ps = spawn(exec, args, { shell: false });
 
         ps.stdout.on('data', (data: Buffer) => {
           this.logger.debug(`stdout: ${data}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -136,21 +136,6 @@ async function bootstrap() {
     serveDotFiles: false
   });
 
-  for (const dir of readdirSync(join(__dirname, '..', 'client', 'vcs'))) {
-    await server.register(fastifyStatic, {
-      root: join(__dirname, '..', 'client', 'vcs', dir),
-      prefix: `/.${dir}`,
-      decorateReply: false,
-      redirect: true,
-      index: false,
-      list: {
-        format: 'html',
-        render: renderDirList
-      },
-      serveDotFiles: true
-    });
-  }
-
   await server.register(fastifyStatic, {
     root: join(__dirname, '..', 'client', 'dist', 'vendor'),
     prefix: `/vendor`,

--- a/src/main.ts
+++ b/src/main.ts
@@ -127,6 +127,25 @@ async function bootstrap() {
     );
   });
 
+  // Block access to VCS metadata (e.g. Mercurial .hg, Git .git, SVN .svn)
+  // that must never be reachable over HTTP, regardless of static file
+  // serving configuration. This hook is registered BEFORE the static
+  // file plugins so that it is inherited by their encapsulated contexts
+  // and actually applies to requests they would otherwise serve.
+  server.addHook('onRequest', (req, reply, done) => {
+    if (/^\/(\.hg|\.git|\.svn|\.bzr|_darcs)(\/|$)/i.test(req.url || '')) {
+      reply.code(404).send({
+        success: false,
+        error: {
+          kind: 'user_input',
+          message: 'Not Found'
+        }
+      });
+      return;
+    }
+    done();
+  });
+
   await server.register(fastifyStatic, {
     root: join(__dirname, '..', 'client', 'dist'),
     prefix: `/`,
@@ -147,23 +166,6 @@ async function bootstrap() {
       render: renderDirList
     },
     serveDotFiles: false
-  });
-
-  // Block access to VCS metadata (e.g. Mercurial .hg, Git .git, SVN .svn)
-  // that must never be reachable over HTTP, regardless of static file
-  // serving configuration.
-  server.addHook('onRequest', (req, reply, done) => {
-    if (/^\/(\.hg|\.git|\.svn|\.bzr|_darcs)(\/|$)/i.test(req.url || '')) {
-      reply.code(404).send({
-        success: false,
-        error: {
-          kind: 'user_input',
-          message: 'Not Found'
-        }
-      });
-      return;
-    }
-    done();
   });
 
   await server.register(fastifyHttpProxy, {

--- a/src/main.ts
+++ b/src/main.ts
@@ -133,7 +133,7 @@ async function bootstrap() {
     decorateReply: false,
     redirect: false,
     wildcard: false,
-    serveDotFiles: true
+    serveDotFiles: false
   });
 
   for (const dir of readdirSync(join(__dirname, '..', 'client', 'vcs'))) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -146,7 +146,24 @@ async function bootstrap() {
       format: 'html',
       render: renderDirList
     },
-    serveDotFiles: true
+    serveDotFiles: false
+  });
+
+  // Block access to VCS metadata (e.g. Mercurial .hg, Git .git, SVN .svn)
+  // that must never be reachable over HTTP, regardless of static file
+  // serving configuration.
+  server.addHook('onRequest', (req, reply, done) => {
+    if (/^\/(\.hg|\.git|\.svn|\.bzr|_darcs)(\/|$)/i.test(req.url || '')) {
+      reply.code(404).send({
+        success: false,
+        error: {
+          kind: 'user_input',
+          message: 'Not Found'
+        }
+      });
+      return;
+    }
+    done();
   });
 
   await server.register(fastifyHttpProxy, {


### PR DESCRIPTION
## 🛡️ Bright Security Scan

**Scan target:** `repository root` at http://localhost:3000

- ✅ **Detecting tech stack**
  - Tech stack: JavaScript, TypeScript, NestJS, PostgreSQL
- ✅ **Building and starting the application**
  - Application running at http://localhost:3000 (repository root)
- ✅ **Setting up Bright security scanner and Repeater**
  - Repeater connected
- ✅ **Completing first-time application setup**
  - Setup completed: BrokenCrystals (NestJS/Fastify + PostgreSQL via MikroORM) has no install/setup wizard.
- ✅ **Preparing application for security scanning**
  - Scan-prep reported success without applying or documenting any rate-limit/security-control change
- ✅ **Detecting authentication requirements**
  - Auth configured
- ✅ **Analyzing source code for endpoints and parameters**
  - 82 endpoints (static analysis)
- ✅ **Registering API endpoints for scanning**
  - 57 live entrypoints after pruning 404s
- ✅ **Selecting relevant security tests per endpoint**
  - Created 10 scan group(s) with per-endpoint test selection
- ✅ **Running scans — round 1**
  - Round 1 complete — 6 vulnerabilities found (1 Critical, 4 High, 1 Medium)
- 🔄 **Fixing 6 vulnerabilities — round 1 (claude-sonnet-5)**